### PR TITLE
sparql.tsのうち、検索ツール間で共通しているものを/app/src/common/utils/sparql.tsへ移動

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -7,7 +7,7 @@ import {
   TableContainer,
   Tbody,
 } from '@chakra-ui/react';
-import { PREFIXES, fetchActivity } from '../root/utils/sparql';
+import { fetchActivity } from '../root/utils/sparql';
 import { SelectActivity } from '../root/components/SelectActivity';
 import { SelectScene } from '../root/components/SelectScene';
 import { SelectCamera } from '../root/components/SelectCamera';
@@ -15,6 +15,7 @@ import { SelectMedia } from '../root/components/SelectMedia';
 import { ResultVideo } from '../root/components/ResultVideo';
 import { ResultImage } from '../root/components/ResultImage';
 import FloatingNavigationLink from '../common/components/FloatingNavigationLink';
+import { PREFIXES } from '../common/utils/sparql';
 
 function ActionObjectSearch() {
   const [activityList, setActivityList] = useState<Map<string, string[]>>(

--- a/app/src/common/utils/sparql.ts
+++ b/app/src/common/utils/sparql.ts
@@ -6,3 +6,10 @@ export const makeClient = () => {
     endpointUrl: `${endpointUrl}?infer=false`,
   });
 };
+
+export const PREFIXES = {
+  ex: 'http://kgrc4si.home.kg/virtualhome2kg/instance/',
+  mssn: 'http://mssn.sigappfr.org/mssn/',
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  vh2kg: 'http://kgrc4si.home.kg/virtualhome2kg/ontology/',
+};

--- a/app/src/common/utils/sparql.ts
+++ b/app/src/common/utils/sparql.ts
@@ -1,0 +1,8 @@
+import ParsingClient from 'sparql-http-client/ParsingClient';
+
+export const makeClient = () => {
+  const endpointUrl = 'http://localhost:7200/repositories/kgrc4si';
+  return new ParsingClient({
+    endpointUrl: `${endpointUrl}?infer=false`,
+  });
+};

--- a/app/src/root/App.tsx
+++ b/app/src/root/App.tsx
@@ -7,7 +7,7 @@ import {
   TableContainer,
   Tbody,
 } from '@chakra-ui/react';
-import { PREFIXES, fetchActivity } from './utils/sparql';
+import { fetchActivity } from './utils/sparql';
 import { SelectActivity } from './components/SelectActivity';
 import { SelectScene } from './components/SelectScene';
 import { SelectCamera } from './components/SelectCamera';
@@ -15,6 +15,7 @@ import { SelectMedia } from './components/SelectMedia';
 import { ResultVideo } from './components/ResultVideo';
 import { ResultImage } from './components/ResultImage';
 import FloatingNavigationLink from '../common/components/FloatingNavigationLink';
+import { PREFIXES } from '../common/utils/sparql';
 
 function App() {
   const [activityList, setActivityList] = useState<Map<string, string[]>>(

--- a/app/src/root/components/SelectAction.tsx
+++ b/app/src/root/components/SelectAction.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { PREFIXES, fetchEvent } from '../utils/sparql';
+import { fetchEvent } from '../utils/sparql';
 import { SelectObject } from './SelectObject';
+import { PREFIXES } from '../../common/utils/sparql';
 
 type EventActionType = { action: string; startFrame: number };
 

--- a/app/src/root/components/SelectCamera.tsx
+++ b/app/src/root/components/SelectCamera.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { PREFIXES, fetchCamera } from '../utils/sparql';
+import { fetchCamera } from '../utils/sparql';
+import { PREFIXES } from '../../common/utils/sparql';
 
 type SelectCameraProps = {
   selectedActivity: string;

--- a/app/src/root/components/SelectObject.tsx
+++ b/app/src/root/components/SelectObject.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import {
-  PREFIXES,
-  fetchObject,
-  fetchStartFrameOfObject,
-} from '../utils/sparql';
+import { fetchObject, fetchStartFrameOfObject } from '../utils/sparql';
+import { PREFIXES } from '../../common/utils/sparql';
 
 type SelectObjectProps = {
   selectedActivity: string;

--- a/app/src/root/utils/sparql.ts
+++ b/app/src/root/utils/sparql.ts
@@ -1,13 +1,6 @@
 import { makeClient } from '../../common/utils/sparql';
 import { NamedNode } from 'rdf-js';
 
-export const PREFIXES = {
-  ex: 'http://kgrc4si.home.kg/virtualhome2kg/instance/',
-  mssn: 'http://mssn.sigappfr.org/mssn/',
-  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-  vh2kg: 'http://kgrc4si.home.kg/virtualhome2kg/ontology/',
-};
-
 export type ActivityQueryType = {
   activity: NamedNode;
 };

--- a/app/src/root/utils/sparql.ts
+++ b/app/src/root/utils/sparql.ts
@@ -1,12 +1,5 @@
-import ParsingClient from 'sparql-http-client/ParsingClient';
+import { makeClient } from '../../common/utils/sparql';
 import { NamedNode } from 'rdf-js';
-
-const makeClient = () => {
-  const endpointUrl = 'http://localhost:7200/repositories/kgrc4si';
-  return new ParsingClient({
-    endpointUrl: `${endpointUrl}?infer=false`,
-  });
-};
 
 export const PREFIXES = {
   ex: 'http://kgrc4si.home.kg/virtualhome2kg/instance/',


### PR DESCRIPTION
## 変更の概要

- 関連するPR: #3 
- 検索ツール間で共通しているSPARQLの関数を/app/src/common/utils/sparql.tsへ移動

## なぜこの変更をするのか

- 既存の検索ツールと新規の検索ツールで同一の関数を使用できるようにするため

## やったこと

- `app/src/root/utils/sparql.ts` -> `app/src/common/utils/sparql.ts` へ `makeClient()` を移動
- `app/src/root/utils/sparql.ts` から移動した`makeClient`をImportするように変更

## やらないこと

- 無し

## できるようになること

- 無し

## できなくなること

- 無し

## 動作確認方法

## その他
