### PR TITLE
相対パスを使用したインポートの禁止

### DIFF
--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -1,15 +1,24 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
-import eslintConfigPrettier from "eslint-config-prettier";
-
+import globals from 'globals';
+import pluginJs from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import pluginReactConfig from 'eslint-plugin-react/configs/recommended.js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths';
 
 export default [
   {
-    files: ["**/*.ts", "**/*.tsx"],
-    ignores: ["**/*.test.ts", "**/*.test.tsx"],
-    languageOptions: { globals: globals.browser }
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['**/*.test.ts', '**/*.test.tsx'],
+    languageOptions: { globals: globals.browser },
+    plugins: {
+      'no-relative-import-paths': noRelativeImportPaths,
+    },
+    rules: {
+      'no-relative-import-paths/no-relative-import-paths': [
+        'error',
+        { rootDir: 'src' },
+      ],
+    },
   },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "@types/sparql-http-client": "^3.0.0",
     "eslint": "8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-no-relative-import-paths": "^1.5.5",
     "eslint-plugin-react": "^7.34.1",
     "globals": "^15.1.0",
     "prettier": "^3.2.5",

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -6,9 +6,9 @@ import {
   Tbody,
 } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
-import { SelectAction } from './components/SelectAction';
-import FloatingNavigationLink from '../common/components/FloatingNavigationLink';
-import { ActionQueryType, fetchAction } from './utils/sparql';
+import { SelectAction } from 'action_object_search/components/SelectAction';
+import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
+import { ActionQueryType, fetchAction } from 'action_object_search/utils/sparql';
 
 function ActionObjectSearch() {
   const [actions, setActions] = useState<ActionQueryType[]>([]);

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { ActionQueryType } from '../utils/sparql';
+import { ActionQueryType } from 'action_object_search/utils/sparql';
 
 export function SelectAction({
   actions,

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -1,5 +1,5 @@
 import { NamedNode } from 'rdf-js';
-import { makeClient } from '../../common/utils/sparql';
+import { makeClient } from 'common/utils/sparql';
 
 export type ActionQueryType = {
   action: NamedNode;

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import './index.css';
-import App from './root/App';
-import ActionObjectSearch from './action_object_search/ActionObjectSearch';
+import 'index.css';
+import App from 'root/App';
+import ActionObjectSearch from 'action_object_search/ActionObjectSearch';
 
 const router = createBrowserRouter([
   {

--- a/app/src/root/App.tsx
+++ b/app/src/root/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import './App.css';
+import 'root/App.css';
 import {
   ChakraProvider,
   Flex,
@@ -7,15 +7,15 @@ import {
   TableContainer,
   Tbody,
 } from '@chakra-ui/react';
-import { fetchActivity } from './utils/sparql';
-import { SelectActivity } from './components/SelectActivity';
-import { SelectScene } from './components/SelectScene';
-import { SelectCamera } from './components/SelectCamera';
-import { SelectMedia } from './components/SelectMedia';
-import { ResultVideo } from './components/ResultVideo';
-import { ResultImage } from './components/ResultImage';
-import FloatingNavigationLink from '../common/components/FloatingNavigationLink';
-import { PREFIXES } from '../common/utils/sparql';
+import { fetchActivity } from 'root/utils/sparql';
+import { SelectActivity } from 'root/components/SelectActivity';
+import { SelectScene } from 'root/components/SelectScene';
+import { SelectCamera } from 'root/components/SelectCamera';
+import { SelectMedia } from 'root/components/SelectMedia';
+import { ResultVideo } from 'root/components/ResultVideo';
+import { ResultImage } from 'root/components/ResultImage';
+import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
+import { PREFIXES } from 'common/utils/sparql';
 
 function App() {
   const [activityList, setActivityList] = useState<Map<string, string[]>>(

--- a/app/src/root/components/ResultImage.tsx
+++ b/app/src/root/components/ResultImage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { fetchImage } from '../utils/sparql';
+import { fetchImage } from 'root/utils/sparql';
 
 type ResultImageProps = {
   selectedActivity: string;

--- a/app/src/root/components/ResultVideo.tsx
+++ b/app/src/root/components/ResultVideo.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { fetchVideo } from '../utils/sparql';
+import { fetchVideo } from 'root/utils/sparql';
 
 type ResultVideoProps = {
   selectedActivity: string;

--- a/app/src/root/components/SelectAction.tsx
+++ b/app/src/root/components/SelectAction.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { fetchEvent } from '../utils/sparql';
-import { SelectObject } from './SelectObject';
-import { PREFIXES } from '../../common/utils/sparql';
+import { fetchEvent } from 'root/utils/sparql';
+import { SelectObject } from 'root/components/SelectObject';
+import { PREFIXES } from 'common/utils/sparql';
 
 type EventActionType = { action: string; startFrame: number };
 

--- a/app/src/root/components/SelectCamera.tsx
+++ b/app/src/root/components/SelectCamera.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { fetchCamera } from '../utils/sparql';
-import { PREFIXES } from '../../common/utils/sparql';
+import { fetchCamera } from 'root/utils/sparql';
+import { PREFIXES } from 'common/utils/sparql';
 
 type SelectCameraProps = {
   selectedActivity: string;

--- a/app/src/root/components/SelectMedia.tsx
+++ b/app/src/root/components/SelectMedia.tsx
@@ -10,7 +10,7 @@ import {
   Th,
   Tr,
 } from '@chakra-ui/react';
-import { SelectAction } from './SelectAction';
+import { SelectAction } from 'root/components/SelectAction';
 
 type SelectMediaProps = {
   selectedActivity: string;

--- a/app/src/root/components/SelectObject.tsx
+++ b/app/src/root/components/SelectObject.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { fetchObject, fetchStartFrameOfObject } from '../utils/sparql';
-import { PREFIXES } from '../../common/utils/sparql';
+import { fetchObject, fetchStartFrameOfObject } from 'root/utils/sparql';
+import { PREFIXES } from 'common/utils/sparql';
 
 type SelectObjectProps = {
   selectedActivity: string;

--- a/app/src/root/utils/sparql.ts
+++ b/app/src/root/utils/sparql.ts
@@ -1,4 +1,4 @@
-import { makeClient } from '../../common/utils/sparql';
+import { makeClient } from 'common/utils/sparql';
 import { NamedNode } from 'rdf-js';
 
 export type ActivityQueryType = {

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,12 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
+    "baseUrl": "./src",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
@@ -21,7 +18,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## 変更の概要

- 相対パスを使用したインポートを禁止するため、[eslint-plugin-no-relative-import-paths](https://www.npmjs.com/package/eslint-plugin-no-relative-import-paths)を導入しました。
- 関連するPR: #4 

## なぜこの変更をするのか

- 相対パスを使用したImportを禁止するためです

## やったこと
- `app/tsconfig.json`に`baseUrl`の記載
- eslint-plugin-no-relative-import-pathsをdevDependenciesに追加
- 上記プラグインの設定を`app/eslint.config.mjs`へ記載
- `yarn lint --fix`で既存の相対Importを変更

## やらないこと

## できるようになること

- eslintで相対パスでのインポートが存在する場合にエラーが表示される

## できなくなること

- 相対パスでのインポート

## 動作確認方法

- `yarn lint`で相対パスでのインポートがある場合にエラーが表示されることを確認しました
- `yarn lint`で相対パスでのインポートがない場合はエラーが表示されないことを確認しました

## その他