### PR TITLE
オブジェクト検索欄の追加

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -6,12 +6,16 @@ import {
   Tbody,
 } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
-import { SelectAction } from 'action_object_search/components/SelectAction';
-import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
-import { ActionQueryType, fetchAction } from 'action_object_search/utils/sparql';
+import { SelectAction } from './components/SelectAction';
+import FloatingNavigationLink from '../common/components/FloatingNavigationLink';
+import { ActionQueryType, fetchAction } from './utils/sparql';
+import { InputObject } from '../action_object_search/components/InputObject';
 
-function ActionObjectSearch() {
+function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
+  const [mainObject, setMainObject] = useState<string>('');
+  const [targetObject, setTargetObject] = useState<string>('');
+
   const [selectedAction, setSelectedAction] = useState<string>('');
 
   useEffect(() => {
@@ -31,6 +35,18 @@ function ActionObjectSearch() {
                 actions={actions}
                 selectedAction={selectedAction}
                 setSelectedAction={setSelectedAction}
+              />
+              <InputObject
+                objectState={mainObject}
+                setObjectState={setMainObject}
+                tableHeader="Main Object"
+                inputPlaceholder="Required"
+              />
+              <InputObject
+                objectState={targetObject}
+                setObjectState={setTargetObject}
+                tableHeader="Target Object"
+                inputPlaceholder="Optional"
               />
             </Tbody>
           </Table>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -6,10 +6,13 @@ import {
   Tbody,
 } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
-import { SelectAction } from './components/SelectAction';
-import FloatingNavigationLink from '../common/components/FloatingNavigationLink';
-import { ActionQueryType, fetchAction } from './utils/sparql';
-import { InputObject } from '../action_object_search/components/InputObject';
+import { SelectAction } from 'action_object_search/components/SelectAction';
+import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
+import {
+  ActionQueryType,
+  fetchAction,
+} from 'action_object_search/utils/sparql';
+import { InputObject } from 'action_object_search/components/InputObject';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);

--- a/app/src/action_object_search/components/InputObject.tsx
+++ b/app/src/action_object_search/components/InputObject.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Input, Td, Th, Tr } from '@chakra-ui/react';
+
+export function InputObject({
+  objectState,
+  setObjectState,
+  tableHeader,
+  inputPlaceholder,
+}: {
+  objectState: string;
+  setObjectState: (mainObject: string) => void;
+  tableHeader: string;
+  inputPlaceholder: string;
+}): React.ReactElement {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setObjectState(event.target.value);
+  };
+
+  return (
+    <>
+      <Tr>
+        <Th width={60} fontSize="large">
+          {tableHeader}
+        </Th>
+        <Td>
+          <Input
+            placeholder={inputPlaceholder}
+            value={objectState}
+            onChange={handleChange}
+          />
+        </Td>
+      </Tr>
+    </>
+  );
+}


### PR DESCRIPTION
## 変更の概要

- mainObject, targetObjectの検索を行うためのInputを追加しました

## なぜこの変更をするのか

- 新規検索機能にて、Object名で検索を行うためです。

## やったこと

- `app/src/action_object_search/components/InputObject.tsx`の実装
- `app/src/action_object_search/components/SelectAction.tsx`に上記の追加

## やらないこと

- 検索機能の追加
こちらは別でPRを作成させていただきます。

## できるようになること

- mainObjectを入力できるようになります
- targetObjectを入力できるようになります

## できなくなること

## 動作確認方法

## その他

下記スクリーンショット・録画をご確認ください。

<img width="1840" alt="Screenshot 2024-11-11 at 17 13 13" src="https://github.com/user-attachments/assets/27c001fd-a4a3-4e8e-9126-cc979816d2c8">

https://github.com/user-attachments/assets/df155db5-3cb1-436d-819d-a97d025ed78f

