### PR TITLE
fetchEvent関数の作成

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -11,11 +11,14 @@ import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
 import {
   ActionQueryType,
   fetchAction,
+  fetchEvent,
 } from 'action_object_search/utils/sparql';
 import { InputObject } from 'action_object_search/components/InputObject';
+import { EventQueryType } from 'action_object_search/utils/sparql';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
+  const [events, setEvents] = useState<EventQueryType[]>([]);
   const [mainObject, setMainObject] = useState<string>('');
   const [targetObject, setTargetObject] = useState<string>('');
 
@@ -26,6 +29,18 @@ function ActionObjectSearch(): React.ReactElement {
       setActions(await fetchAction());
     })();
   }, []);
+
+  useEffect(() => {
+    if (selectedAction === '') {
+      return;
+    }
+    if (mainObject === '') {
+      return;
+    }
+    (async () => {
+      setEvents(await fetchEvent(selectedAction, mainObject, targetObject));
+    })();
+  }, [selectedAction, mainObject, targetObject]);
 
   return (
     <ChakraProvider>

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -14,3 +14,30 @@ export const fetchAction: () => Promise<ActionQueryType[]> = async () => {
   const result = (await makeClient().query.select(query)) as ActionQueryType[];
   return result;
 };
+
+export type EventQueryType = {
+  event: NamedNode;
+};
+export const fetchEvent: (
+  action: string,
+  mainObject: string,
+  targetObject: string
+) => Promise<EventQueryType[]> = async (action, mainObject, targetObject) => {
+  const query = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    SELECT DISTINCT ?event WHERE {
+      ?mainObject rdfs:label ?mainObjectLabel FILTER regex(?mainObjectLabel, "${mainObject}", "i") .
+      ${
+        targetObject !== ''
+          ? `?targetObject rdfs:label ?targetObjectLabel FILTER regex(?targetObjectLabel, "${targetObject}", "i") .`
+          : ''
+      }
+      ?event vh2kg:mainObject ?mainObject ;
+             ${targetObject !== '' ? 'vh2kg:targetObject ?targetObject ;' : ''}
+             vh2kg:action <${action}> .
+    } ORDER BY asc(?event)
+  `;
+  const result = (await makeClient().query.select(query)) as EventQueryType[];
+  return result;
+};


### PR DESCRIPTION
## 変更の概要

- 指定したActionとObjectに該当するEventを取得する関数を追加しました

## なぜこの変更をするのか

- 新規検索ツールにおいて、指定されたActionとObjectを含むEventを含む動画（セグメント）を取得する機能を実装するためです。

## やったこと

- `app/src/action_object_search/utils/sparql.ts`に`fetchEvent`関数を作成しました
- `app/src/action_object_search/ActionObjectSearch.tsx`に`events`Stateを更新する処理を追加しました

## やらないこと

## できるようになること

新規検索ツールで、フォームの内容をもとに該当するイベントを検索できるようになります。

## できなくなること

## 動作確認方法

## その他

添付の録画をご確認ください。
**※動作確認用の要素を使用しておりますが、こちらはコミットの内容に含まれておりません。**

https://github.com/user-attachments/assets/a1a2ee6a-a75e-4964-9653-1eed8c7564dd