### PR TITLE
Add video search

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -21,6 +21,7 @@ import {
 } from 'action_object_search/components/VideoDurationRadio';
 import { VideoGrid } from 'action_object_search/components/VideoGrid';
 import { InputPageNumber } from 'action_object_search/components/InputPageNumber';
+import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
@@ -32,8 +33,6 @@ function ActionObjectSearch(): React.ReactElement {
   const [selectedAction, setSelectedAction] = useState<string>('');
   const [selectedVideoDuration, setSelectedVideoDuration] =
     useState<VideoDurationType>('full');
-
-  const TOTAL_VIDEOS_PER_PAGE = 9;
 
   useEffect(() => {
     (async () => {

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -15,9 +15,12 @@ import {
   VideoQueryType,
 } from 'action_object_search/utils/sparql';
 import { InputObject } from 'action_object_search/components/InputObject';
-import { VideoDurationRadio } from './components/VideoDurationRadio';
-import { VideoGrid } from './components/VideoGrid';
-import { InputPageNumber } from './components/InputPageNumber';
+import {
+  VideoDurationRadio,
+  VideoDurationType,
+} from 'action_object_search/components/VideoDurationRadio';
+import { VideoGrid } from 'action_object_search/components/VideoGrid';
+import { InputPageNumber } from 'action_object_search/components/InputPageNumber';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
@@ -28,7 +31,9 @@ function ActionObjectSearch(): React.ReactElement {
 
   const [selectedAction, setSelectedAction] = useState<string>('');
   const [selectedVideoDuration, setSelectedVideoDuration] =
-    useState<string>('full');
+    useState<VideoDurationType>('full');
+
+  const TOTAL_VIDEOS_PER_PAGE = 9;
 
   useEffect(() => {
     (async () => {
@@ -50,7 +55,13 @@ function ActionObjectSearch(): React.ReactElement {
     (async () => {
       if (selectedVideoDuration === 'full') {
         setVideos(
-          await fetchVideo(selectedAction, mainObject, targetObject, 9, page) // TODO: 9(一度に取得する動画の上限)に関しては後ほど調整可能とする
+          await fetchVideo(
+            selectedAction,
+            mainObject,
+            targetObject,
+            TOTAL_VIDEOS_PER_PAGE,
+            page
+          )
         );
       }
     })();

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -13,6 +13,7 @@ import {
   fetchAction,
 } from 'action_object_search/utils/sparql';
 import { InputObject } from 'action_object_search/components/InputObject';
+import { VideoDurationRadio } from './components/VideoDurationRadio';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
@@ -20,6 +21,8 @@ function ActionObjectSearch(): React.ReactElement {
   const [targetObject, setTargetObject] = useState<string>('');
 
   const [selectedAction, setSelectedAction] = useState<string>('');
+  const [selectedVideoDuration, setSelectedVideoDuration] =
+    useState<string>('full');
 
   useEffect(() => {
     (async () => {
@@ -50,6 +53,10 @@ function ActionObjectSearch(): React.ReactElement {
                 setObjectState={setTargetObject}
                 tableHeader="Target Object"
                 inputPlaceholder="Optional"
+              />
+              <VideoDurationRadio
+                selectedVideoDuration={selectedVideoDuration}
+                setSelectedVideoDuration={setSelectedVideoDuration}
               />
             </Tbody>
           </Table>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -11,14 +11,20 @@ import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
 import {
   ActionQueryType,
   fetchAction,
+  fetchVideo,
+  VideoQueryType,
 } from 'action_object_search/utils/sparql';
 import { InputObject } from 'action_object_search/components/InputObject';
 import { VideoDurationRadio } from './components/VideoDurationRadio';
+import { VideoGrid } from './components/VideoGrid';
+import { InputPageNumber } from './components/InputPageNumber';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
   const [mainObject, setMainObject] = useState<string>('');
   const [targetObject, setTargetObject] = useState<string>('');
+  const [videos, setVideos] = useState<VideoQueryType[]>([]);
+  const [page, setPage] = useState<number>(1);
 
   const [selectedAction, setSelectedAction] = useState<string>('');
   const [selectedVideoDuration, setSelectedVideoDuration] =
@@ -29,6 +35,26 @@ function ActionObjectSearch(): React.ReactElement {
       setActions(await fetchAction());
     })();
   }, []);
+
+  useEffect(() => {
+    if (selectedAction === '') {
+      return;
+    }
+    if (mainObject === '') {
+      return;
+    }
+    if (isNaN(page)) {
+      return;
+    }
+
+    (async () => {
+      if (selectedVideoDuration === 'full') {
+        setVideos(
+          await fetchVideo(selectedAction, mainObject, targetObject, 9, page) // TODO: 9(一度に取得する動画の上限)に関しては後ほど調整可能とする
+        );
+      }
+    })();
+  }, [selectedAction, mainObject, targetObject, selectedVideoDuration, page]);
 
   return (
     <ChakraProvider>
@@ -58,9 +84,11 @@ function ActionObjectSearch(): React.ReactElement {
                 selectedVideoDuration={selectedVideoDuration}
                 setSelectedVideoDuration={setSelectedVideoDuration}
               />
+              <InputPageNumber page={page} setPage={setPage} />
             </Tbody>
           </Table>
         </TableContainer>
+        <VideoGrid videos={videos} />
       </Flex>
     </ChakraProvider>
   );

--- a/app/src/action_object_search/components/InputPageNumber.tsx
+++ b/app/src/action_object_search/components/InputPageNumber.tsx
@@ -1,0 +1,40 @@
+import {
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  Td,
+  Th,
+  Tr,
+} from '@chakra-ui/react';
+
+export function InputPageNumber({
+  page,
+  setPage,
+}: {
+  page: number;
+  setPage: (page: number) => void;
+}) {
+  return (
+    <Tr>
+      <Th width={60} fontSize="large">
+        Page
+      </Th>
+      <Td>
+        <NumberInput
+          value={page}
+          onChange={(pageNumberString) => setPage(parseInt(pageNumberString))}
+          defaultValue={1}
+          min={1}
+        >
+          <NumberInputField />
+          <NumberInputStepper>
+            <NumberIncrementStepper />
+            <NumberDecrementStepper />
+          </NumberInputStepper>
+        </NumberInput>
+      </Td>
+    </Tr>
+  );
+}

--- a/app/src/action_object_search/components/InputPageNumber.tsx
+++ b/app/src/action_object_search/components/InputPageNumber.tsx
@@ -8,6 +8,7 @@ import {
   Th,
   Tr,
 } from '@chakra-ui/react';
+import React from 'react';
 
 export function InputPageNumber({
   page,
@@ -15,7 +16,7 @@ export function InputPageNumber({
 }: {
   page: number;
   setPage: (page: number) => void;
-}) {
+}): React.ReactElement {
   return (
     <Tr>
       <Th width={60} fontSize="large">

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { Radio, RadioGroup, Select, Stack, Td, Th, Tr } from '@chakra-ui/react';
+import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
 
+export type VideoDurationType = 'full' | 'segment';
 export function VideoDurationRadio({
   selectedVideoDuration,
   setSelectedVideoDuration,
 }: {
-  selectedVideoDuration: string;
-  setSelectedVideoDuration: (videoDuration: string) => void;
+  selectedVideoDuration: VideoDurationType;
+  setSelectedVideoDuration: (videoDuration: VideoDurationType) => void;
 }): React.ReactElement {
   return (
     <>

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
 
 export type VideoDurationType = 'full' | 'segment';
+type VideoDurationRadioProps = {
+  selectedVideoDuration: VideoDurationType;
+  setSelectedVideoDuration: (videoDuration: VideoDurationType) => void;
+};
 export function VideoDurationRadio({
   selectedVideoDuration,
   setSelectedVideoDuration,
-}: {
-  selectedVideoDuration: VideoDurationType;
-  setSelectedVideoDuration: (videoDuration: VideoDurationType) => void;
-}): React.ReactElement {
+}: VideoDurationRadioProps): React.ReactElement {
   return (
     <>
       <Tr>

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Radio, RadioGroup, Select, Stack, Td, Th, Tr } from '@chakra-ui/react';
+
+export function VideoDurationRadio({
+  selectedVideoDuration,
+  setSelectedVideoDuration,
+}: {
+  selectedVideoDuration: string;
+  setSelectedVideoDuration: (videoDuration: string) => void;
+}): React.ReactElement {
+  return (
+    <>
+      <Tr>
+        <Th width={60} fontSize="large">
+          Video Duration
+        </Th>
+        <Td>
+          <RadioGroup
+            onChange={setSelectedVideoDuration}
+            value={selectedVideoDuration}
+          >
+            <Stack direction="row">
+              <Radio value="full">Full</Radio>
+              <Radio value="segment" isDisabled>
+                Segment
+              </Radio>
+            </Stack>
+          </RadioGroup>
+        </Td>
+      </Tr>
+    </>
+  );
+}

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -1,0 +1,36 @@
+import { Grid, GridItem, Text } from '@chakra-ui/react';
+import { VideoQueryType } from 'action_object_search/utils/sparql';
+
+export function VideoGrid({
+  videos,
+}: {
+  videos: VideoQueryType[];
+}): React.ReactElement {
+  return (
+    <Grid templateColumns="repeat(3, 1fr)" gap={4}>
+      {videos.map((video) => (
+        <GridItem
+          key={video.camera.value}
+          p={2}
+          border="1px"
+          borderColor="gray.200"
+          rounded="xl"
+        >
+          <Text fontSize="sm" color="gray.600" align="center" mb={2}>
+            {video.camera.value.split('/').pop()}
+          </Text>
+          <video
+            src={`data:video/mp4;base64,${video.base64Video.value}`}
+            controls
+            width="100%"
+            height="auto"
+            onClick={(e) => {
+              e.preventDefault();
+              // TODO: 2D Bounding Boxを表示する
+            }}
+          />
+        </GridItem>
+      ))}
+    </Grid>
+  );
+}

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -1,12 +1,12 @@
-import { Grid, GridItem, Text } from '@chakra-ui/react';
+import { Grid, GridItem, Link } from '@chakra-ui/react';
 import { VideoQueryType } from 'action_object_search/utils/sparql';
-import { Link } from 'react-router-dom';
+import React from 'react';
+import { Link as ReactRouterLink } from 'react-router-dom';
 
-export function VideoGrid({
-  videos,
-}: {
+type VideoGridProps = {
   videos: VideoQueryType[];
-}): React.ReactElement {
+};
+export function VideoGrid({ videos }: VideoGridProps): React.ReactElement {
   return (
     <Grid templateColumns="repeat(3, 1fr)" gap={4}>
       {videos.map((video) => (
@@ -23,17 +23,8 @@ export function VideoGrid({
             width="100%"
             height="auto"
           />
-          <Link to={``} state={{}}>
-            {/* stateを使用するためにreact-router-domのLink要素を使用 */}
-            <Text
-              fontSize="sm"
-              color="gray.600"
-              align="center"
-              mt="2"
-              _hover={{ textDecoration: 'underline' }}
-            >
-              {video.camera.value.split('/').pop()}
-            </Text>
+          <Link as={ReactRouterLink} to={``} state={{}}>
+            {video.camera.value.split('/').pop()}
           </Link>
         </GridItem>
       ))}

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -1,5 +1,6 @@
 import { Grid, GridItem, Text } from '@chakra-ui/react';
 import { VideoQueryType } from 'action_object_search/utils/sparql';
+import { Link } from 'react-router-dom';
 
 export function VideoGrid({
   videos,
@@ -16,19 +17,24 @@ export function VideoGrid({
           borderColor="gray.200"
           rounded="xl"
         >
-          <Text fontSize="sm" color="gray.600" align="center" mb={2}>
-            {video.camera.value.split('/').pop()}
-          </Text>
           <video
             src={`data:video/mp4;base64,${video.base64Video.value}`}
             controls
             width="100%"
             height="auto"
-            onClick={(e) => {
-              e.preventDefault();
-              // TODO: 2D Bounding Boxを表示する
-            }}
           />
+          <Link to={``} state={{}}>
+            {/* stateを使用するためにreact-router-domのLink要素を使用 */}
+            <Text
+              fontSize="sm"
+              color="gray.600"
+              align="center"
+              mt="2"
+              _hover={{ textDecoration: 'underline' }}
+            >
+              {video.camera.value.split('/').pop()}
+            </Text>
+          </Link>
         </GridItem>
       ))}
     </Grid>

--- a/app/src/action_object_search/constants.ts
+++ b/app/src/action_object_search/constants.ts
@@ -1,0 +1,1 @@
+export const TOTAL_VIDEOS_PER_PAGE = 9;

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -14,3 +14,14 @@ export const fetchAction: () => Promise<ActionQueryType[]> = async () => {
   const result = (await makeClient().query.select(query)) as ActionQueryType[];
   return result;
 };
+
+export type VideoQueryType = {
+  video: NamedNode;
+};
+export const fetchVideo: () => Promise<VideoQueryType[]> = async () => {
+  const query = `
+    
+  `;
+  const result = (await makeClient().query.select(query)) as VideoQueryType[];
+  return result;
+};

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -16,11 +16,39 @@ export const fetchAction: () => Promise<ActionQueryType[]> = async () => {
 };
 
 export type VideoQueryType = {
-  video: NamedNode;
+  camera: NamedNode;
+  base64Video: NamedNode;
 };
-export const fetchVideo: () => Promise<VideoQueryType[]> = async () => {
+export const fetchVideo: (
+  action: string,
+  mainObject: string,
+  targetObject: string,
+  limit: number,
+  page: number
+) => Promise<VideoQueryType[]> = async (
+  action,
+  mainObject,
+  targetObject,
+  limit,
+  page
+) => {
   const query = `
-    
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    SELECT DISTINCT ?camera ?base64Video WHERE {
+      ?mainObject rdfs:label ?mainObjectLabel FILTER regex(?mainObjectLabel, "${mainObject}", "i") .
+      ${
+        targetObject !== ''
+          ? `?targetObject rdfs:label ?targetObjectLabel FILTER regex(?targetObjectLabel, "${targetObject}", "i") .`
+          : ''
+      }
+      ?event vh2kg:mainObject ?mainObject ;
+             ${targetObject !== '' ? 'vh2kg:targetObject ?targetObject ;' : ''}
+             vh2kg:action <${action}> .
+      ?activity vh2kg:hasEvent ?event ;
+                vh2kg:hasVideo ?camera .
+      ?camera vh2kg:video ?base64Video .
+    } ORDER BY asc(?camera) LIMIT ${limit} OFFSET ${limit * (page - 1)}
   `;
   const result = (await makeClient().query.select(query)) as VideoQueryType[];
   return result;


### PR DESCRIPTION
## 変更の概要

- Videoの検索機能を追加しました

## なぜこの変更をするのか

- 新規検索ツールにおける検索対象の1つであるためです

## やったこと

- 検索結果に表示する項目を動画か動画セグメントで切り替えるためのRadio要素の作成
- 検索結果のページを移動するためのInput要素の作成
- 検索結果として動画を表示するグリッドの作成

## やらないこと

- camera, scene別の検索機能
こちらは次に追加します

- videoSegmentの表示機能
上記が完了次第追加します

## できるようになること

- ActionとObjectを含む動画を検索結果として表示することができます

## できなくなること

## 動作確認方法

## その他

添付のスクリーンショットと録画をご確認ください。

<img width="1840" alt="Screenshot 2024-11-12 at 14 44 27" src="https://github.com/user-attachments/assets/9e73621f-4a89-4e18-9d80-25f833e9ad03">


https://github.com/user-attachments/assets/bebdad28-c57a-433c-927d-a228ed054c01

