### PR TITLE
Add total video fetch

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -12,6 +12,7 @@ import {
   ActionQueryType,
   fetchAction,
   fetchVideo,
+  fetchVideoCount,
   VideoQueryType,
 } from 'action_object_search/utils/sparql';
 import { InputObject } from 'action_object_search/components/InputObject';
@@ -29,6 +30,7 @@ function ActionObjectSearch(): React.ReactElement {
   const [mainObject, setMainObject] = useState<string>('');
   const [targetObject, setTargetObject] = useState<string>('');
   const [videos, setVideos] = useState<VideoQueryType[]>([]);
+  const [videoCount, setVideoCount] = useState<number>(0);
 
   const [selectedAction, setSelectedAction] = useState<string>('');
   const [selectedVideoDuration, setSelectedVideoDuration] =
@@ -60,6 +62,9 @@ function ActionObjectSearch(): React.ReactElement {
             TOTAL_VIDEOS_PER_PAGE,
             Number(searchParams.get('searchResultPage')) || 1
           )
+        );
+        setVideoCount(
+          await fetchVideoCount(selectedAction, mainObject, targetObject)
         );
       }
     })();
@@ -103,11 +108,10 @@ function ActionObjectSearch(): React.ReactElement {
           </Table>
         </TableContainer>
         <VideoGrid videos={videos} />
-        {/* TODO: 取得する動画の合計を取得し、totalVideosへ反映させる */}
         <Pagination
           searchParams={searchParams}
           setSearchParams={setSearchParams}
-          totalVideos={100}
+          totalVideos={videoCount}
         />
       </Flex>
     </ChakraProvider>

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -65,7 +65,7 @@ export const fetchVideoCount: (
   const query = `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
-    SELECT DISTINCT (COUNT(*) AS ?videoCount) WHERE {
+    SELECT (COUNT(DISTINCT ?camera) AS ?videoCount) WHERE {
       ?mainObject rdfs:label ?mainObjectLabel FILTER regex(?mainObjectLabel, "${mainObject}", "i") .
       ${
         targetObject !== ''
@@ -77,7 +77,6 @@ export const fetchVideoCount: (
              vh2kg:action <${action}> .
       ?activity vh2kg:hasEvent ?event ;
                 vh2kg:hasVideo ?camera .
-      ?camera vh2kg:video ?base64Video .
     }
   `;
   const result = (await makeClient().query.select(


### PR DESCRIPTION
## 変更の概要

- 動画検索時に、検索にヒットする動画総数を取得する処理を追加しました

## なぜこの変更をするのか

- 検索時に動画の総数を取得することで、ページネーションのページの数を、実際の動画の数と合わせることをできるようにするためです。

## やったこと

- `app/src/action_object_search/utils/sparql.ts`に`fetchVideoCount`関数の追加
- `Pagination`要素に上記の関数の結果を渡すように変更し、実際の動画の数と合致したページ数を表示するように変更

## やらないこと

- 検索回数の削減（`useMemo`）
次の変更で検索に使用しているパラメータ(`action`, `mainObject`, `targetObject`)が変数`searchParams`（クエリパラメータ）へ移動するためです。
`searchParams`は選択されているページを示す`page`というプロパティも持ちます。したがって、`useMemo`を使用してもページの変更のみで動画の総数を取得する処理が行われてしまうためです。
（別の解決策を考えています…）

## できるようになること

- Paginationが実際の動画の数に対応したページ数を表示できるようになります。

## できなくなること

## 動作確認方法

- 実際に検索を行い、paginationが動画の総数と合致していることを確認しました。
<img width="1840" alt="Screenshot 2024-11-15 at 13 12 53" src="https://github.com/user-attachments/assets/d02e9a08-255c-43c2-b720-3e9fcc310b20">

<img width="1840" alt="Screenshot 2024-11-15 at 13 14 12" src="https://github.com/user-attachments/assets/ffe9ef07-f58f-4f5b-a64f-9b8e900ff2a4">

## その他
