### PR TITLE
クエリパラメータに検索内容を保存する処理の追加

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -18,8 +18,8 @@ import {
   type SearchParamObjectKey,
   MAIN_OBJECT_KEY,
   SEARCH_RESULT_PAGE_KEY,
-  SELETED_ACTION_KEY,
-  SELETED_VIDEO_DURATION_KEY,
+  ACTION_KEY,
+  VIDEO_DURATION_KEY,
   TARGET_OBJECT_KEY,
   TOTAL_VIDEOS_PER_PAGE,
 } from 'action_object_search/constants';
@@ -42,7 +42,7 @@ function ActionObjectSearch(): React.ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [selectedAction, setSelectedAction] = useState<string>(
-    searchParams.get(SELETED_ACTION_KEY) || ''
+    searchParams.get(ACTION_KEY) || ''
   );
   const [mainObject, setMainObject] = useState<string>(
     searchParams.get(MAIN_OBJECT_KEY) || ''
@@ -52,8 +52,7 @@ function ActionObjectSearch(): React.ReactElement {
   );
   const [selectedVideoDuration, setSelectedVideoDuration] =
     useState<VideoDurationType>(
-      (searchParams.get(SELETED_VIDEO_DURATION_KEY) as VideoDurationType) ||
-        'full'
+      (searchParams.get(VIDEO_DURATION_KEY) as VideoDurationType) || 'full'
     );
   const [searchResultPage, setSearchResultPage] = useState<number>(
     Number(searchParams.get(SEARCH_RESULT_PAGE_KEY)) || 1

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -25,28 +25,42 @@ import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
 import { Pagination } from 'action_object_search/components/Pagination';
 import { useSearchParams } from 'react-router-dom';
 
+export type SearchParamObjectKey = 'mainObject' | 'targetObject';
+type SearchParamKey =
+  | 'selectedAction'
+  | 'selectedVideoDuration'
+  | 'searchResultPage'
+  | SearchParamObjectKey;
+
+export const selectedActionKey: SearchParamKey = 'selectedAction';
+export const mainObjectKey: SearchParamKey = 'mainObject';
+export const targetObjectKey: SearchParamKey = 'targetObject';
+export const selectedVideoDurationKey: SearchParamKey = 'selectedVideoDuration';
+export const searchResultPageKey: SearchParamKey = 'searchResultPage';
+
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
   const [videos, setVideos] = useState<VideoQueryType[]>([]);
   const [videoCount, setVideoCount] = useState<number>(0);
 
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [selectedAction, setSelectedAction] = useState<string>(
-    searchParams.get('selectedAction') || ''
+    searchParams.get(selectedActionKey) || ''
   );
   const [mainObject, setMainObject] = useState<string>(
-    searchParams.get('mainObject') || ''
+    searchParams.get(mainObjectKey) || ''
   );
   const [targetObject, setTargetObject] = useState<string>(
-    searchParams.get('targetObject') || ''
+    searchParams.get(targetObjectKey) || ''
   );
   const [selectedVideoDuration, setSelectedVideoDuration] =
     useState<VideoDurationType>(
-      (searchParams.get('selectedVideoDuration') as VideoDurationType) || 'full'
+      (searchParams.get(selectedVideoDurationKey) as VideoDurationType) ||
+        'full'
     );
   const [searchResultPage, setSearchResultPage] = useState<number>(
-    Number(searchParams.get('searchResultPage')) || 1
+    Number(searchParams.get(searchResultPageKey)) || 1
   );
 
   useEffect(() => {
@@ -109,25 +123,33 @@ function ActionObjectSearch(): React.ReactElement {
               <SelectAction
                 actions={actions}
                 selectedAction={selectedAction}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
                 setSelectedAction={setSelectedAction}
               />
               <InputObject
-                objectType="mainObject"
+                searchParamObjectKey={mainObjectKey as SearchParamObjectKey}
                 objectState={mainObject}
                 setObjectState={setMainObject}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
                 tableHeader="Main Object"
                 inputPlaceholder="Required"
               />
               <InputObject
-                objectType="targetObject"
+                searchParamObjectKey={targetObjectKey as SearchParamObjectKey}
                 objectState={targetObject}
                 setObjectState={setTargetObject}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
                 tableHeader="Target Object"
                 inputPlaceholder="Optional"
               />
               <VideoDurationRadio
                 selectedVideoDuration={selectedVideoDuration}
                 setSelectedVideoDuration={setSelectedVideoDuration}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
               />
             </Tbody>
           </Table>
@@ -136,6 +158,8 @@ function ActionObjectSearch(): React.ReactElement {
         <Pagination
           searchResultPage={searchResultPage}
           setSearchResultPage={setSearchResultPage}
+          searchParams={searchParams}
+          setSearchParams={setSearchParams}
           totalVideos={videoCount}
         />
       </Flex>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -16,10 +16,7 @@ import {
   VideoQueryType,
 } from 'action_object_search/utils/sparql';
 import { InputObject } from 'action_object_search/components/InputObject';
-import {
-  VideoDurationRadio,
-  VideoDurationType,
-} from 'action_object_search/components/VideoDurationRadio';
+import { VideoDurationRadio } from 'action_object_search/components/VideoDurationRadio';
 import { VideoGrid } from 'action_object_search/components/VideoGrid';
 import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
 import { Pagination } from 'action_object_search/components/Pagination';
@@ -27,14 +24,8 @@ import { useSearchParams } from 'react-router-dom';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
-  const [mainObject, setMainObject] = useState<string>('');
-  const [targetObject, setTargetObject] = useState<string>('');
   const [videos, setVideos] = useState<VideoQueryType[]>([]);
   const [videoCount, setVideoCount] = useState<number>(0);
-
-  const [selectedAction, setSelectedAction] = useState<string>('');
-  const [selectedVideoDuration, setSelectedVideoDuration] =
-    useState<VideoDurationType>('full');
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -45,20 +36,20 @@ function ActionObjectSearch(): React.ReactElement {
   }, []);
 
   useEffect(() => {
-    if (selectedAction === '') {
+    if (!searchParams.get('action')) {
       return;
     }
-    if (mainObject === '') {
+    if (!searchParams.get('mainObject')) {
       return;
     }
 
     (async () => {
-      if (selectedVideoDuration === 'full') {
+      if (searchParams.get('videoDuration') === 'full') {
         setVideos(
           await fetchVideo(
-            selectedAction,
-            mainObject,
-            targetObject,
+            searchParams.get('action') as string,
+            searchParams.get('mainObject') as string,
+            searchParams.get('targetObject') || '',
             TOTAL_VIDEOS_PER_PAGE,
             Number(searchParams.get('searchResultPage')) || 1
           )
@@ -68,13 +59,7 @@ function ActionObjectSearch(): React.ReactElement {
         );
       }
     })();
-  }, [
-    selectedAction,
-    mainObject,
-    targetObject,
-    selectedVideoDuration,
-    searchParams,
-  ]);
+  }, [searchParams]);
 
   return (
     <ChakraProvider>
@@ -85,24 +70,26 @@ function ActionObjectSearch(): React.ReactElement {
             <Tbody>
               <SelectAction
                 actions={actions}
-                selectedAction={selectedAction}
-                setSelectedAction={setSelectedAction}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
               />
               <InputObject
-                objectState={mainObject}
-                setObjectState={setMainObject}
+                objectType="mainObject"
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
                 tableHeader="Main Object"
                 inputPlaceholder="Required"
               />
               <InputObject
-                objectState={targetObject}
-                setObjectState={setTargetObject}
+                objectType="targetObject"
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
                 tableHeader="Target Object"
                 inputPlaceholder="Optional"
               />
               <VideoDurationRadio
-                selectedVideoDuration={selectedVideoDuration}
-                setSelectedVideoDuration={setSelectedVideoDuration}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
               />
             </Tbody>
           </Table>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -5,7 +5,7 @@ import {
   TableContainer,
   Tbody,
 } from '@chakra-ui/react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { SelectAction } from 'action_object_search/components/SelectAction';
 import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
 import {
@@ -21,22 +21,18 @@ import {
   VideoDurationType,
 } from 'action_object_search/components/VideoDurationRadio';
 import { VideoGrid } from 'action_object_search/components/VideoGrid';
-import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
+import {
+  mainObjectKey,
+  SearchParamKey,
+  SearchParamObjectKey,
+  searchResultPageKey,
+  selectedActionKey,
+  selectedVideoDurationKey,
+  targetObjectKey,
+  TOTAL_VIDEOS_PER_PAGE,
+} from 'action_object_search/constants';
 import { Pagination } from 'action_object_search/components/Pagination';
 import { useSearchParams } from 'react-router-dom';
-
-export type SearchParamObjectKey = 'mainObject' | 'targetObject';
-type SearchParamKey =
-  | 'selectedAction'
-  | 'selectedVideoDuration'
-  | 'searchResultPage'
-  | SearchParamObjectKey;
-
-export const selectedActionKey: SearchParamKey = 'selectedAction';
-export const mainObjectKey: SearchParamKey = 'mainObject';
-export const targetObjectKey: SearchParamKey = 'targetObject';
-export const selectedVideoDurationKey: SearchParamKey = 'selectedVideoDuration';
-export const searchResultPageKey: SearchParamKey = 'searchResultPage';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
@@ -61,6 +57,15 @@ function ActionObjectSearch(): React.ReactElement {
     );
   const [searchResultPage, setSearchResultPage] = useState<number>(
     Number(searchParams.get(searchResultPageKey)) || 1
+  );
+
+  const handleSearchParamsChange = useCallback(
+    (key: SearchParamKey, value: string) => {
+      const newSearchParams = new URLSearchParams(searchParams);
+      newSearchParams.set(key, value);
+      setSearchParams(newSearchParams);
+    },
+    [searchParams, setSearchParams]
   );
 
   useEffect(() => {
@@ -98,7 +103,7 @@ function ActionObjectSearch(): React.ReactElement {
     searchResultPage,
   ]);
 
-  useMemo(() => {
+  useEffect(() => {
     (async () => {
       if (selectedAction === '') {
         return;
@@ -111,7 +116,7 @@ function ActionObjectSearch(): React.ReactElement {
         await fetchVideoCount(selectedAction, mainObject, targetObject)
       );
     })();
-  }, [selectedAction, mainObject, targetObject, selectedVideoDuration]);
+  }, [selectedAction, mainObject, targetObject]);
 
   return (
     <ChakraProvider>
@@ -123,16 +128,14 @@ function ActionObjectSearch(): React.ReactElement {
               <SelectAction
                 actions={actions}
                 selectedAction={selectedAction}
-                searchParams={searchParams}
-                setSearchParams={setSearchParams}
                 setSelectedAction={setSelectedAction}
+                handleSearchParamsChange={handleSearchParamsChange}
               />
               <InputObject
                 searchParamObjectKey={mainObjectKey as SearchParamObjectKey}
                 objectState={mainObject}
                 setObjectState={setMainObject}
-                searchParams={searchParams}
-                setSearchParams={setSearchParams}
+                handleSearchParamsChange={handleSearchParamsChange}
                 tableHeader="Main Object"
                 inputPlaceholder="Required"
               />
@@ -140,16 +143,14 @@ function ActionObjectSearch(): React.ReactElement {
                 searchParamObjectKey={targetObjectKey as SearchParamObjectKey}
                 objectState={targetObject}
                 setObjectState={setTargetObject}
-                searchParams={searchParams}
-                setSearchParams={setSearchParams}
+                handleSearchParamsChange={handleSearchParamsChange}
                 tableHeader="Target Object"
                 inputPlaceholder="Optional"
               />
               <VideoDurationRadio
                 selectedVideoDuration={selectedVideoDuration}
                 setSelectedVideoDuration={setSelectedVideoDuration}
-                searchParams={searchParams}
-                setSearchParams={setSearchParams}
+                handleSearchParamsChange={handleSearchParamsChange}
               />
             </Tbody>
           </Table>
@@ -158,8 +159,7 @@ function ActionObjectSearch(): React.ReactElement {
         <Pagination
           searchResultPage={searchResultPage}
           setSearchResultPage={setSearchResultPage}
-          searchParams={searchParams}
-          setSearchParams={setSearchParams}
+          handleSearchParamsChange={handleSearchParamsChange}
           totalVideos={videoCount}
         />
       </Flex>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -22,13 +22,13 @@ import {
 } from 'action_object_search/components/VideoDurationRadio';
 import { VideoGrid } from 'action_object_search/components/VideoGrid';
 import {
-  mainObjectKey,
-  SearchParamKey,
-  SearchParamObjectKey,
-  searchResultPageKey,
-  selectedActionKey,
-  selectedVideoDurationKey,
-  targetObjectKey,
+  type SearchParamKey,
+  type SearchParamObjectKey,
+  MAIN_OBJECT_KEY,
+  SEARCH_RESULT_PAGE_KEY,
+  SELETED_ACTION_KEY,
+  SELETED_VIDEO_DURATION_KEY,
+  TARGET_OBJECT_KEY,
   TOTAL_VIDEOS_PER_PAGE,
 } from 'action_object_search/constants';
 import { Pagination } from 'action_object_search/components/Pagination';
@@ -42,21 +42,21 @@ function ActionObjectSearch(): React.ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [selectedAction, setSelectedAction] = useState<string>(
-    searchParams.get(selectedActionKey) || ''
+    searchParams.get(SELETED_ACTION_KEY) || ''
   );
   const [mainObject, setMainObject] = useState<string>(
-    searchParams.get(mainObjectKey) || ''
+    searchParams.get(MAIN_OBJECT_KEY) || ''
   );
   const [targetObject, setTargetObject] = useState<string>(
-    searchParams.get(targetObjectKey) || ''
+    searchParams.get(TARGET_OBJECT_KEY) || ''
   );
   const [selectedVideoDuration, setSelectedVideoDuration] =
     useState<VideoDurationType>(
-      (searchParams.get(selectedVideoDurationKey) as VideoDurationType) ||
+      (searchParams.get(SELETED_VIDEO_DURATION_KEY) as VideoDurationType) ||
         'full'
     );
   const [searchResultPage, setSearchResultPage] = useState<number>(
-    Number(searchParams.get(searchResultPageKey)) || 1
+    Number(searchParams.get(SEARCH_RESULT_PAGE_KEY)) || 1
   );
 
   const handleSearchParamsChange = useCallback(
@@ -132,7 +132,7 @@ function ActionObjectSearch(): React.ReactElement {
                 handleSearchParamsChange={handleSearchParamsChange}
               />
               <InputObject
-                searchParamObjectKey={mainObjectKey as SearchParamObjectKey}
+                searchParamObjectKey={MAIN_OBJECT_KEY as SearchParamObjectKey}
                 objectState={mainObject}
                 setObjectState={setMainObject}
                 handleSearchParamsChange={handleSearchParamsChange}
@@ -140,7 +140,7 @@ function ActionObjectSearch(): React.ReactElement {
                 inputPlaceholder="Required"
               />
               <InputObject
-                searchParamObjectKey={targetObjectKey as SearchParamObjectKey}
+                searchParamObjectKey={TARGET_OBJECT_KEY as SearchParamObjectKey}
                 objectState={targetObject}
                 setObjectState={setTargetObject}
                 handleSearchParamsChange={handleSearchParamsChange}

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -5,20 +5,12 @@ import {
   TableContainer,
   Tbody,
 } from '@chakra-ui/react';
-import React, { useCallback, useEffect, useState } from 'react';
-import { SelectAction } from 'action_object_search/components/SelectAction';
-import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
-import {
-  ActionQueryType,
-  fetchAction,
-  fetchVideo,
-  fetchVideoCount,
-  VideoQueryType,
-} from 'action_object_search/utils/sparql';
 import { InputObject } from 'action_object_search/components/InputObject';
+import { Pagination } from 'action_object_search/components/Pagination';
+import { SelectAction } from 'action_object_search/components/SelectAction';
 import {
   VideoDurationRadio,
-  VideoDurationType,
+  type VideoDurationType,
 } from 'action_object_search/components/VideoDurationRadio';
 import { VideoGrid } from 'action_object_search/components/VideoGrid';
 import {
@@ -31,7 +23,15 @@ import {
   TARGET_OBJECT_KEY,
   TOTAL_VIDEOS_PER_PAGE,
 } from 'action_object_search/constants';
-import { Pagination } from 'action_object_search/components/Pagination';
+import {
+  type ActionQueryType,
+  fetchAction,
+  fetchVideo,
+  fetchVideoCount,
+  type VideoQueryType,
+} from 'action_object_search/utils/sparql';
+import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 function ActionObjectSearch(): React.ReactElement {

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -32,8 +32,8 @@ function ActionObjectSearch(): React.ReactElement {
 
   const [searchParams] = useSearchParams();
 
-  const [action, setAction] = useState<string>(
-    searchParams.get('action') || ''
+  const [selectedAction, setSelectedAction] = useState<string>(
+    searchParams.get('selectedAction') || ''
   );
   const [mainObject, setMainObject] = useState<string>(
     searchParams.get('mainObject') || ''
@@ -41,9 +41,10 @@ function ActionObjectSearch(): React.ReactElement {
   const [targetObject, setTargetObject] = useState<string>(
     searchParams.get('targetObject') || ''
   );
-  const [videoDuration, setVideoDuration] = useState<VideoDurationType>(
-    (searchParams.get('videoDuration') as VideoDurationType) || 'full'
-  );
+  const [selectedVideoDuration, setSelectedVideoDuration] =
+    useState<VideoDurationType>(
+      (searchParams.get('selectedVideoDuration') as VideoDurationType) || 'full'
+    );
   const [searchResultPage, setSearchResultPage] = useState<number>(
     Number(searchParams.get('searchResultPage')) || 1
   );
@@ -55,7 +56,7 @@ function ActionObjectSearch(): React.ReactElement {
   }, []);
 
   useEffect(() => {
-    if (action === '') {
+    if (selectedAction === '') {
       return;
     }
     if (mainObject === '') {
@@ -63,10 +64,10 @@ function ActionObjectSearch(): React.ReactElement {
     }
 
     (async () => {
-      if (videoDuration === 'full') {
+      if (selectedVideoDuration === 'full') {
         setVideos(
           await fetchVideo(
-            action,
+            selectedAction,
             mainObject,
             targetObject,
             TOTAL_VIDEOS_PER_PAGE,
@@ -75,20 +76,28 @@ function ActionObjectSearch(): React.ReactElement {
         );
       }
     })();
-  }, [action, mainObject, targetObject, videoDuration, searchResultPage]);
+  }, [
+    selectedAction,
+    mainObject,
+    targetObject,
+    selectedVideoDuration,
+    searchResultPage,
+  ]);
 
   useMemo(() => {
     (async () => {
-      if (action === '') {
+      if (selectedAction === '') {
         return;
       }
       if (mainObject === '') {
         return;
       }
 
-      setVideoCount(await fetchVideoCount(action, mainObject, targetObject));
+      setVideoCount(
+        await fetchVideoCount(selectedAction, mainObject, targetObject)
+      );
     })();
-  }, [action, mainObject, targetObject, videoDuration]);
+  }, [selectedAction, mainObject, targetObject, selectedVideoDuration]);
 
   return (
     <ChakraProvider>
@@ -99,8 +108,8 @@ function ActionObjectSearch(): React.ReactElement {
             <Tbody>
               <SelectAction
                 actions={actions}
-                action={action}
-                setAction={setAction}
+                selectedAction={selectedAction}
+                setSelectedAction={setSelectedAction}
               />
               <InputObject
                 objectType="mainObject"
@@ -117,8 +126,8 @@ function ActionObjectSearch(): React.ReactElement {
                 inputPlaceholder="Optional"
               />
               <VideoDurationRadio
-                videoDuration={videoDuration}
-                setVideoDuration={setVideoDuration}
+                selectedVideoDuration={selectedVideoDuration}
+                setSelectedVideoDuration={setSelectedVideoDuration}
               />
             </Tbody>
           </Table>

--- a/app/src/action_object_search/components/InputObject.tsx
+++ b/app/src/action_object_search/components/InputObject.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
 import { Input, Td, Th, Tr } from '@chakra-ui/react';
-import { useSearchParams } from 'react-router-dom';
+import { SearchParamObjectKey } from 'action_object_search/ActionObjectSearch';
 
 type InputObjectProps = {
-  objectType: string;
+  searchParamObjectKey: SearchParamObjectKey;
   objectState: string;
   setObjectState: (objectState: string) => void;
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
   tableHeader: string;
   inputPlaceholder: string;
 };
 export function InputObject({
-  objectType,
+  searchParamObjectKey,
   objectState,
   setObjectState,
+  searchParams,
+  setSearchParams,
   tableHeader,
   inputPlaceholder,
 }: InputObjectProps): React.ReactElement {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setObjectState(event.target.value);
-    searchParams.set(objectType, event.target.value);
+    searchParams.set(searchParamObjectKey, event.target.value);
     setSearchParams(searchParams);
   };
 

--- a/app/src/action_object_search/components/InputObject.tsx
+++ b/app/src/action_object_search/components/InputObject.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Input, Td, Th, Tr } from '@chakra-ui/react';
-import { SearchParamObjectKey } from 'action_object_search/ActionObjectSearch';
+import {
+  SearchParamKey,
+  SearchParamObjectKey,
+} from 'action_object_search/constants';
 
 type InputObjectProps = {
   searchParamObjectKey: SearchParamObjectKey;
   objectState: string;
   setObjectState: (objectState: string) => void;
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
   tableHeader: string;
   inputPlaceholder: string;
 };
@@ -15,16 +17,20 @@ export function InputObject({
   searchParamObjectKey,
   objectState,
   setObjectState,
-  searchParams,
-  setSearchParams,
+  handleSearchParamsChange,
   tableHeader,
   inputPlaceholder,
 }: InputObjectProps): React.ReactElement {
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setObjectState(event.target.value);
-    searchParams.set(searchParamObjectKey, event.target.value);
-    setSearchParams(searchParams);
-  };
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setObjectState(event.target.value);
+      handleSearchParamsChange(
+        searchParamObjectKey as SearchParamKey,
+        event.target.value
+      );
+    },
+    [searchParamObjectKey, setObjectState, handleSearchParamsChange]
+  );
 
   return (
     <>

--- a/app/src/action_object_search/components/InputObject.tsx
+++ b/app/src/action_object_search/components/InputObject.tsx
@@ -24,10 +24,7 @@ export function InputObject({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setObjectState(event.target.value);
-      handleSearchParamsChange(
-        searchParamObjectKey as SearchParamKey,
-        event.target.value
-      );
+      handleSearchParamsChange(searchParamObjectKey, event.target.value);
     },
     [searchParamObjectKey, setObjectState, handleSearchParamsChange]
   );

--- a/app/src/action_object_search/components/InputObject.tsx
+++ b/app/src/action_object_search/components/InputObject.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback } from 'react';
 import { Input, Td, Th, Tr } from '@chakra-ui/react';
-import {
+import type {
   SearchParamKey,
   SearchParamObjectKey,
 } from 'action_object_search/constants';
+import React, { useCallback } from 'react';
 
 type InputObjectProps = {
   searchParamObjectKey: SearchParamObjectKey;

--- a/app/src/action_object_search/components/InputObject.tsx
+++ b/app/src/action_object_search/components/InputObject.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
 import { Input, Td, Th, Tr } from '@chakra-ui/react';
 
-export function InputObject({
-  objectState,
-  setObjectState,
-  tableHeader,
-  inputPlaceholder,
-}: {
-  objectState: string;
-  setObjectState: (mainObject: string) => void;
+type InputObjectProps = {
+  objectType: string;
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
   tableHeader: string;
   inputPlaceholder: string;
-}): React.ReactElement {
+};
+export function InputObject({
+  objectType,
+  searchParams,
+  setSearchParams,
+  tableHeader,
+  inputPlaceholder,
+}: InputObjectProps): React.ReactElement {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setObjectState(event.target.value);
+    searchParams.set(objectType, event.target.value);
+    setSearchParams(searchParams);
   };
 
   return (
@@ -25,7 +29,7 @@ export function InputObject({
         <Td>
           <Input
             placeholder={inputPlaceholder}
-            value={objectState}
+            value={searchParams.get(objectType) || ''}
             onChange={handleChange}
           />
         </Td>

--- a/app/src/action_object_search/components/InputObject.tsx
+++ b/app/src/action_object_search/components/InputObject.tsx
@@ -1,21 +1,25 @@
 import React from 'react';
 import { Input, Td, Th, Tr } from '@chakra-ui/react';
+import { useSearchParams } from 'react-router-dom';
 
 type InputObjectProps = {
   objectType: string;
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  objectState: string;
+  setObjectState: (objectState: string) => void;
   tableHeader: string;
   inputPlaceholder: string;
 };
 export function InputObject({
   objectType,
-  searchParams,
-  setSearchParams,
+  objectState,
+  setObjectState,
   tableHeader,
   inputPlaceholder,
 }: InputObjectProps): React.ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setObjectState(event.target.value);
     searchParams.set(objectType, event.target.value);
     setSearchParams(searchParams);
   };
@@ -29,7 +33,7 @@ export function InputObject({
         <Td>
           <Input
             placeholder={inputPlaceholder}
-            value={searchParams.get(objectType) || ''}
+            value={objectState}
             onChange={handleChange}
           />
         </Td>

--- a/app/src/action_object_search/components/Pagination.tsx
+++ b/app/src/action_object_search/components/Pagination.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonGroup, HStack } from '@chakra-ui/react';
 import {
   SearchParamKey,
-  searchResultPageKey,
+  SEARCH_RESULT_PAGE_KEY,
 } from 'action_object_search/constants';
 import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
 import React, { useCallback, useState } from 'react';
@@ -38,34 +38,59 @@ export function Pagination({
         return;
       }
       setSearchResultPage(Number(page));
-      handleSearchParamsChange(searchResultPageKey, page);
+      handleSearchParamsChange(SEARCH_RESULT_PAGE_KEY, page);
     },
     [setSearchResultPage, handleSearchParamsChange]
   );
 
-  const displayPreviousPage = useCallback(() => {
-    if (displayedPagesStart === 1) {
-      return;
-    }
-    setDisplayedPagesStart(
-      (prevDisplayedPagesStart) =>
-        prevDisplayedPagesStart - totalDisplayablePages
-    );
-  }, [displayedPagesStart]);
+  const hasPreviousPage = displayedPagesStart !== 1;
+  const hasNextPage = displayedPagesStart + totalDisplayablePages <= totalPages;
 
-  const displayNextPage = useCallback(() => {
-    if (displayedPagesStart + totalDisplayablePages > totalPages) {
-      return;
-    }
-    setDisplayedPagesStart(
-      (prevDisplayedPagesStart) =>
-        prevDisplayedPagesStart + totalDisplayablePages
-    );
-  }, [displayedPagesStart, totalPages]);
+  const handlePageMoveButtonClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      const direction = event.currentTarget.dataset.direction;
+      if (direction === undefined) {
+        return;
+      }
+      switch (direction) {
+        case 'previous':
+          if (!hasPreviousPage) {
+            return;
+          }
+          setDisplayedPagesStart(
+            (prevDisplayedPagesStart) =>
+              prevDisplayedPagesStart - totalDisplayablePages
+          );
+          break;
+
+        case 'next':
+          if (!hasNextPage) {
+            return;
+          }
+          setDisplayedPagesStart(
+            (prevDisplayedPagesStart) =>
+              prevDisplayedPagesStart + totalDisplayablePages
+          );
+          break;
+      }
+    },
+    [
+      displayedPagesStart,
+      setDisplayedPagesStart,
+      totalDisplayablePages,
+      totalPages,
+    ]
+  );
 
   return (
     <HStack mx="auto" my={2}>
-      <Button onClick={displayPreviousPage}>Previous</Button>
+      <Button
+        data-direction="previous"
+        onClick={handlePageMoveButtonClick}
+        isDisabled={!hasPreviousPage}
+      >
+        Previous
+      </Button>
       <ButtonGroup>
         {displayedPages.map((pageNumber) => (
           <Button
@@ -79,7 +104,13 @@ export function Pagination({
           </Button>
         ))}
       </ButtonGroup>
-      <Button onClick={displayNextPage}>Next</Button>
+      <Button
+        data-direction="next"
+        onClick={handlePageMoveButtonClick}
+        isDisabled={!hasNextPage}
+      >
+        Next
+      </Button>
     </HStack>
   );
 }

--- a/app/src/action_object_search/components/Pagination.tsx
+++ b/app/src/action_object_search/components/Pagination.tsx
@@ -1,19 +1,22 @@
 import { Button, ButtonGroup, HStack } from '@chakra-ui/react';
 import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
 import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 type PaginationProps = {
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  searchResultPage: number;
+  setSearchResultPage: (searchResultPage: number) => void;
   totalVideos: number;
   totalDisplayablePages?: number;
 };
 export function Pagination({
-  searchParams,
-  setSearchParams,
+  searchResultPage,
+  setSearchResultPage,
   totalVideos,
   totalDisplayablePages = 10,
 }: PaginationProps): React.ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const totalPages = Math.ceil(totalVideos / TOTAL_VIDEOS_PER_PAGE);
 
   const makeDisplayedPagesArray = (displayedPagesStart: number) => {
@@ -49,6 +52,7 @@ export function Pagination({
   };
 
   const handlePageNumberButtonClick = (pageNumber: number) => {
+    setSearchResultPage(pageNumber);
     searchParams.set('searchResultPage', pageNumber.toString());
     setSearchParams(searchParams);
   };
@@ -64,11 +68,7 @@ export function Pagination({
             key={pageNumber}
             onClick={() => handlePageNumberButtonClick(pageNumber)}
             width={'50px'}
-            colorScheme={
-              pageNumber === Number(searchParams.get('searchResultPage'))
-                ? 'blue'
-                : 'gray'
-            }
+            colorScheme={pageNumber === searchResultPage ? 'blue' : 'gray'}
           >
             {pageNumber}
           </Button>

--- a/app/src/action_object_search/components/Pagination.tsx
+++ b/app/src/action_object_search/components/Pagination.tsx
@@ -1,9 +1,9 @@
 import { Button, ButtonGroup, HStack } from '@chakra-ui/react';
 import {
-  SearchParamKey,
+  type SearchParamKey,
   SEARCH_RESULT_PAGE_KEY,
+  TOTAL_VIDEOS_PER_PAGE,
 } from 'action_object_search/constants';
-import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
 import React, { useCallback, useState } from 'react';
 
 type PaginationProps = {

--- a/app/src/action_object_search/components/Pagination.tsx
+++ b/app/src/action_object_search/components/Pagination.tsx
@@ -1,21 +1,22 @@
 import { Button, ButtonGroup, HStack } from '@chakra-ui/react';
-import { searchResultPageKey } from 'action_object_search/ActionObjectSearch';
+import {
+  SearchParamKey,
+  searchResultPageKey,
+} from 'action_object_search/constants';
 import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 type PaginationProps = {
   searchResultPage: number;
   setSearchResultPage: (searchResultPage: number) => void;
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
   totalVideos: number;
   totalDisplayablePages?: number;
 };
 export function Pagination({
   searchResultPage,
   setSearchResultPage,
-  searchParams,
-  setSearchParams,
+  handleSearchParamsChange,
   totalVideos,
   totalDisplayablePages = 10,
 }: PaginationProps): React.ReactElement {
@@ -30,19 +31,19 @@ export function Pagination({
   const [displayedPagesStart, setDisplayedPagesStart] = useState(1);
   const displayedPages = makeDisplayedPagesArray(displayedPagesStart);
 
-  const handlePageNumberButtonClick = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
-    const page = event.currentTarget.dataset.page;
-    if (page === undefined) {
-      return;
-    }
-    setSearchResultPage(Number(page));
-    searchParams.set(searchResultPageKey, page);
-    setSearchParams(searchParams);
-  };
+  const handlePageNumberButtonClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      const page = event.currentTarget.dataset.page;
+      if (page === undefined) {
+        return;
+      }
+      setSearchResultPage(Number(page));
+      handleSearchParamsChange(searchResultPageKey, page);
+    },
+    [setSearchResultPage, handleSearchParamsChange]
+  );
 
-  const displayPreviousPage = () => {
+  const displayPreviousPage = useCallback(() => {
     if (displayedPagesStart === 1) {
       return;
     }
@@ -50,9 +51,9 @@ export function Pagination({
       (prevDisplayedPagesStart) =>
         prevDisplayedPagesStart - totalDisplayablePages
     );
-  };
+  }, [displayedPagesStart]);
 
-  const displayNextPage = () => {
+  const displayNextPage = useCallback(() => {
     if (displayedPagesStart + totalDisplayablePages > totalPages) {
       return;
     }
@@ -60,7 +61,7 @@ export function Pagination({
       (prevDisplayedPagesStart) =>
         prevDisplayedPagesStart + totalDisplayablePages
     );
-  };
+  }, [displayedPagesStart, totalPages]);
 
   return (
     <HStack mx="auto" my={2}>

--- a/app/src/action_object_search/components/Pagination.tsx
+++ b/app/src/action_object_search/components/Pagination.tsx
@@ -1,22 +1,24 @@
 import { Button, ButtonGroup, HStack } from '@chakra-ui/react';
+import { searchResultPageKey } from 'action_object_search/ActionObjectSearch';
 import { TOTAL_VIDEOS_PER_PAGE } from 'action_object_search/constants';
 import React, { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 type PaginationProps = {
   searchResultPage: number;
   setSearchResultPage: (searchResultPage: number) => void;
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
   totalVideos: number;
   totalDisplayablePages?: number;
 };
 export function Pagination({
   searchResultPage,
   setSearchResultPage,
+  searchParams,
+  setSearchParams,
   totalVideos,
   totalDisplayablePages = 10,
 }: PaginationProps): React.ReactElement {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const totalPages = Math.ceil(totalVideos / TOTAL_VIDEOS_PER_PAGE);
 
   const makeDisplayedPagesArray = (displayedPagesStart: number) => {
@@ -28,45 +30,47 @@ export function Pagination({
   const [displayedPagesStart, setDisplayedPagesStart] = useState(1);
   const displayedPages = makeDisplayedPagesArray(displayedPagesStart);
 
-  const handlePageMoveButtonClick = (direction: 'next' | 'previous') => {
-    switch (direction) {
-      case 'next':
-        if (displayedPagesStart + totalDisplayablePages > totalPages) {
-          return;
-        }
-        setDisplayedPagesStart(
-          (prevDisplayedPagesStart) =>
-            prevDisplayedPagesStart + totalDisplayablePages
-        );
-        break;
-      case 'previous':
-        if (displayedPagesStart === 1) {
-          return;
-        }
-        setDisplayedPagesStart(
-          (prevDisplayedPagesStart) =>
-            prevDisplayedPagesStart - totalDisplayablePages
-        );
-        break;
+  const handlePageNumberButtonClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    const page = event.currentTarget.dataset.page;
+    if (page === undefined) {
+      return;
     }
+    setSearchResultPage(Number(page));
+    searchParams.set(searchResultPageKey, page);
+    setSearchParams(searchParams);
   };
 
-  const handlePageNumberButtonClick = (pageNumber: number) => {
-    setSearchResultPage(pageNumber);
-    searchParams.set('searchResultPage', pageNumber.toString());
-    setSearchParams(searchParams);
+  const displayPreviousPage = () => {
+    if (displayedPagesStart === 1) {
+      return;
+    }
+    setDisplayedPagesStart(
+      (prevDisplayedPagesStart) =>
+        prevDisplayedPagesStart - totalDisplayablePages
+    );
+  };
+
+  const displayNextPage = () => {
+    if (displayedPagesStart + totalDisplayablePages > totalPages) {
+      return;
+    }
+    setDisplayedPagesStart(
+      (prevDisplayedPagesStart) =>
+        prevDisplayedPagesStart + totalDisplayablePages
+    );
   };
 
   return (
     <HStack mx="auto" my={2}>
-      <Button onClick={() => handlePageMoveButtonClick('previous')}>
-        Previous
-      </Button>
+      <Button onClick={displayPreviousPage}>Previous</Button>
       <ButtonGroup>
         {displayedPages.map((pageNumber) => (
           <Button
             key={pageNumber}
-            onClick={() => handlePageNumberButtonClick(pageNumber)}
+            data-page={pageNumber}
+            onClick={handlePageNumberButtonClick}
             width={'50px'}
             colorScheme={pageNumber === searchResultPage ? 'blue' : 'gray'}
           >
@@ -74,7 +78,7 @@ export function Pagination({
           </Button>
         ))}
       </ButtonGroup>
-      <Button onClick={() => handlePageMoveButtonClick('next')}>Next</Button>
+      <Button onClick={displayNextPage}>Next</Button>
     </HStack>
   );
 }

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -1,21 +1,30 @@
 import React from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { ActionQueryType } from 'action_object_search/utils/sparql';
+import { useSearchParams } from 'react-router-dom';
 
 type SelectActionProps = {
   actions: ActionQueryType[];
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  action: string;
+  setAction: (action: string) => void;
 };
 export function SelectAction({
   actions,
-  searchParams,
-  setSearchParams,
+  action,
+  setAction,
 }: SelectActionProps): React.ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const options = actions.map((action) => ({
     value: action.action.value,
     label: action.action.value.split('/').pop(), // vh2kg:action/<Action>から<Action>を取得
   }));
+
+  const handleChange = (value: string) => {
+    setAction(value);
+    searchParams.set('action', value);
+    setSearchParams(searchParams);
+  };
 
   return (
     <>
@@ -26,11 +35,9 @@ export function SelectAction({
         <Td>
           <Select
             placeholder="select"
-            value={searchParams.get('action') || ''}
+            value={action}
             onChange={(e) => {
-              const action = e.target.value;
-              searchParams.set('action', action);
-              setSearchParams(searchParams);
+              handleChange(e.target.value);
             }}
           >
             {options.map((option) => (

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -3,7 +3,7 @@ import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { ActionQueryType } from 'action_object_search/utils/sparql';
 import {
   SearchParamKey,
-  selectedActionKey,
+  SELETED_ACTION_KEY,
 } from 'action_object_search/constants';
 
 type SelectActionProps = {
@@ -26,7 +26,7 @@ export function SelectAction({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {
       setSelectedAction(event.target.value);
-      handleSearchParamsChange(selectedActionKey, event.target.value);
+      handleSearchParamsChange(SELETED_ACTION_KEY, event.target.value);
     },
     [setSelectedAction, handleSearchParamsChange]
   );

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -5,13 +5,13 @@ import { useSearchParams } from 'react-router-dom';
 
 type SelectActionProps = {
   actions: ActionQueryType[];
-  action: string;
-  setAction: (action: string) => void;
+  selectedAction: string;
+  setSelectedAction: (action: string) => void;
 };
 export function SelectAction({
   actions,
-  action,
-  setAction,
+  selectedAction,
+  setSelectedAction,
 }: SelectActionProps): React.ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -21,8 +21,8 @@ export function SelectAction({
   }));
 
   const handleChange = (value: string) => {
-    setAction(value);
-    searchParams.set('action', value);
+    setSelectedAction(value);
+    searchParams.set('selectedAction', value);
     setSearchParams(searchParams);
   };
 
@@ -35,7 +35,7 @@ export function SelectAction({
         <Td>
           <Select
             placeholder="select"
-            value={action}
+            value={selectedAction}
             onChange={(e) => {
               handleChange(e.target.value);
             }}

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { ActionQueryType } from 'action_object_search/utils/sparql';
 import {
-  SearchParamKey,
+  type SearchParamKey,
   SELETED_ACTION_KEY,
 } from 'action_object_search/constants';
+import { type ActionQueryType } from 'action_object_search/utils/sparql';
+import React, { useCallback } from 'react';
 
 type SelectActionProps = {
   actions: ActionQueryType[];

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { ActionQueryType } from 'action_object_search/utils/sparql';
 
+type SelectActionProps = {
+  actions: ActionQueryType[];
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
+};
 export function SelectAction({
   actions,
-  selectedAction,
-  setSelectedAction,
-}: {
-  actions: ActionQueryType[];
-  selectedAction: string;
-  setSelectedAction: (action: string) => void;
-}): React.ReactElement {
+  searchParams,
+  setSearchParams,
+}: SelectActionProps): React.ReactElement {
   const options = actions.map((action) => ({
     value: action.action.value,
     label: action.action.value.split('/').pop(), // vh2kg:action/<Action>から<Action>を取得
@@ -25,10 +26,11 @@ export function SelectAction({
         <Td>
           <Select
             placeholder="select"
-            value={selectedAction}
+            value={searchParams.get('action') || ''}
             onChange={(e) => {
               const action = e.target.value;
-              setSelectedAction(action);
+              searchParams.set('action', action);
+              setSearchParams(searchParams);
             }}
           >
             {options.map((option) => (

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { ActionQueryType } from 'action_object_search/utils/sparql';
-import { useSearchParams } from 'react-router-dom';
+import { selectedActionKey } from 'action_object_search/ActionObjectSearch';
 
 type SelectActionProps = {
   actions: ActionQueryType[];
   selectedAction: string;
   setSelectedAction: (action: string) => void;
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
 };
 export function SelectAction({
   actions,
   selectedAction,
   setSelectedAction,
+  searchParams,
+  setSearchParams,
 }: SelectActionProps): React.ReactElement {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const options = actions.map((action) => ({
     value: action.action.value,
     label: action.action.value.split('/').pop(), // vh2kg:action/<Action>から<Action>を取得
@@ -22,7 +24,7 @@ export function SelectAction({
 
   const handleChange = (value: string) => {
     setSelectedAction(value);
-    searchParams.set('selectedAction', value);
+    searchParams.set(selectedActionKey, value);
     setSearchParams(searchParams);
   };
 

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -1,7 +1,7 @@
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import {
   type SearchParamKey,
-  SELETED_ACTION_KEY,
+  ACTION_KEY,
 } from 'action_object_search/constants';
 import { type ActionQueryType } from 'action_object_search/utils/sparql';
 import React, { useCallback } from 'react';
@@ -26,7 +26,7 @@ export function SelectAction({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {
       setSelectedAction(event.target.value);
-      handleSearchParamsChange(SELETED_ACTION_KEY, event.target.value);
+      handleSearchParamsChange(ACTION_KEY, event.target.value);
     },
     [setSelectedAction, handleSearchParamsChange]
   );

--- a/app/src/action_object_search/components/SelectAction.tsx
+++ b/app/src/action_object_search/components/SelectAction.tsx
@@ -1,32 +1,35 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { ActionQueryType } from 'action_object_search/utils/sparql';
-import { selectedActionKey } from 'action_object_search/ActionObjectSearch';
+import {
+  SearchParamKey,
+  selectedActionKey,
+} from 'action_object_search/constants';
 
 type SelectActionProps = {
   actions: ActionQueryType[];
   selectedAction: string;
   setSelectedAction: (action: string) => void;
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
 };
 export function SelectAction({
   actions,
   selectedAction,
   setSelectedAction,
-  searchParams,
-  setSearchParams,
+  handleSearchParamsChange,
 }: SelectActionProps): React.ReactElement {
   const options = actions.map((action) => ({
     value: action.action.value,
     label: action.action.value.split('/').pop(), // vh2kg:action/<Action>から<Action>を取得
   }));
 
-  const handleChange = (value: string) => {
-    setSelectedAction(value);
-    searchParams.set(selectedActionKey, value);
-    setSearchParams(searchParams);
-  };
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedAction(event.target.value);
+      handleSearchParamsChange(selectedActionKey, event.target.value);
+    },
+    [setSelectedAction, handleSearchParamsChange]
+  );
 
   return (
     <>
@@ -38,9 +41,7 @@ export function SelectAction({
           <Select
             placeholder="select"
             value={selectedAction}
-            onChange={(e) => {
-              handleChange(e.target.value);
-            }}
+            onChange={handleChange}
           >
             {options.map((option) => (
               <option key={option.value} value={option.value}>

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback } from 'react';
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
 import {
-  SearchParamKey,
+  type SearchParamKey,
   SELETED_VIDEO_DURATION_KEY,
 } from 'action_object_search/constants';
+import React, { useCallback } from 'react';
 
 export type VideoDurationType = 'full' | 'segment';
 type VideoDurationRadioProps = {

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -4,18 +4,18 @@ import { useSearchParams } from 'react-router-dom';
 
 export type VideoDurationType = 'full' | 'segment';
 type VideoDurationRadioProps = {
-  videoDuration: VideoDurationType;
-  setVideoDuration: (videoDuration: VideoDurationType) => void;
+  selectedVideoDuration: VideoDurationType;
+  setSelectedVideoDuration: (videoDuration: VideoDurationType) => void;
 };
 export function VideoDurationRadio({
-  videoDuration,
-  setVideoDuration,
+  selectedVideoDuration,
+  setSelectedVideoDuration,
 }: VideoDurationRadioProps): React.ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const handleChange = (value: VideoDurationType) => {
-    setVideoDuration(value);
-    searchParams.set('videoDuration', value);
+    setSelectedVideoDuration(value);
+    searchParams.set('selectedVideoDuration', value);
     setSearchParams(searchParams);
   };
 
@@ -30,7 +30,7 @@ export function VideoDurationRadio({
             onChange={(value) => {
               handleChange(value as VideoDurationType);
             }}
-            value={videoDuration}
+            value={selectedVideoDuration}
           >
             <Stack direction="row">
               <Radio value="full">Full</Radio>

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
-import { useSearchParams } from 'react-router-dom';
+import { selectedVideoDurationKey } from 'action_object_search/ActionObjectSearch';
 
 export type VideoDurationType = 'full' | 'segment';
 type VideoDurationRadioProps = {
   selectedVideoDuration: VideoDurationType;
   setSelectedVideoDuration: (videoDuration: VideoDurationType) => void;
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
 };
 export function VideoDurationRadio({
   selectedVideoDuration,
   setSelectedVideoDuration,
+  searchParams,
+  setSearchParams,
 }: VideoDurationRadioProps): React.ReactElement {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const handleChange = (value: VideoDurationType) => {
     setSelectedVideoDuration(value);
-    searchParams.set('selectedVideoDuration', value);
+    searchParams.set(selectedVideoDurationKey, value);
     setSearchParams(searchParams);
   };
 

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,25 +1,28 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
-import { selectedVideoDurationKey } from 'action_object_search/ActionObjectSearch';
+import {
+  SearchParamKey,
+  selectedVideoDurationKey,
+} from 'action_object_search/constants';
 
 export type VideoDurationType = 'full' | 'segment';
 type VideoDurationRadioProps = {
   selectedVideoDuration: VideoDurationType;
   setSelectedVideoDuration: (videoDuration: VideoDurationType) => void;
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
 };
 export function VideoDurationRadio({
   selectedVideoDuration,
   setSelectedVideoDuration,
-  searchParams,
-  setSearchParams,
+  handleSearchParamsChange,
 }: VideoDurationRadioProps): React.ReactElement {
-  const handleChange = (value: VideoDurationType) => {
-    setSelectedVideoDuration(value);
-    searchParams.set(selectedVideoDurationKey, value);
-    setSearchParams(searchParams);
-  };
+  const handleChange = useCallback(
+    (value: VideoDurationType) => {
+      setSelectedVideoDuration(value);
+      handleSearchParamsChange(selectedVideoDurationKey, value);
+    },
+    [setSelectedVideoDuration, handleSearchParamsChange]
+  );
 
   return (
     <>
@@ -28,12 +31,7 @@ export function VideoDurationRadio({
           Video Duration
         </Th>
         <Td>
-          <RadioGroup
-            onChange={(value) => {
-              handleChange(value as VideoDurationType);
-            }}
-            value={selectedVideoDuration}
-          >
+          <RadioGroup onChange={handleChange} value={selectedVideoDuration}>
             <Stack direction="row">
               <Radio value="full">Full</Radio>
               <Radio value="segment">Segment</Radio>

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
 
-export type VideoDurationType = 'full' | 'segment';
+type VideoDurationType = 'full' | 'segment';
 type VideoDurationRadioProps = {
-  selectedVideoDuration: VideoDurationType;
-  setSelectedVideoDuration: (videoDuration: VideoDurationType) => void;
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
 };
 export function VideoDurationRadio({
-  selectedVideoDuration,
-  setSelectedVideoDuration,
+  searchParams,
+  setSearchParams,
 }: VideoDurationRadioProps): React.ReactElement {
+  const handleChange = (value: VideoDurationType) => {
+    searchParams.set('videoDuration', value);
+    setSearchParams(searchParams);
+  };
   return (
     <>
       <Tr>
@@ -18,14 +22,14 @@ export function VideoDurationRadio({
         </Th>
         <Td>
           <RadioGroup
-            onChange={setSelectedVideoDuration}
-            value={selectedVideoDuration}
+            onChange={(value) => {
+              handleChange(value as VideoDurationType);
+            }}
+            value={searchParams.get('videoDuration') || 'full'}
           >
             <Stack direction="row">
               <Radio value="full">Full</Radio>
-              <Radio value="segment" isDisabled>
-                Segment
-              </Radio>
+              <Radio value="segment">Segment</Radio>
             </Stack>
           </RadioGroup>
         </Td>

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,7 +1,7 @@
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
 import {
   type SearchParamKey,
-  SELETED_VIDEO_DURATION_KEY,
+  VIDEO_DURATION_KEY,
 } from 'action_object_search/constants';
 import React, { useCallback } from 'react';
 
@@ -19,7 +19,7 @@ export function VideoDurationRadio({
   const handleChange = useCallback(
     (value: VideoDurationType) => {
       setSelectedVideoDuration(value);
-      handleSearchParamsChange(SELETED_VIDEO_DURATION_KEY, value);
+      handleSearchParamsChange(VIDEO_DURATION_KEY, value);
     },
     [setSelectedVideoDuration, handleSearchParamsChange]
   );

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
+import { useSearchParams } from 'react-router-dom';
 
-type VideoDurationType = 'full' | 'segment';
+export type VideoDurationType = 'full' | 'segment';
 type VideoDurationRadioProps = {
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  videoDuration: VideoDurationType;
+  setVideoDuration: (videoDuration: VideoDurationType) => void;
 };
 export function VideoDurationRadio({
-  searchParams,
-  setSearchParams,
+  videoDuration,
+  setVideoDuration,
 }: VideoDurationRadioProps): React.ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const handleChange = (value: VideoDurationType) => {
+    setVideoDuration(value);
     searchParams.set('videoDuration', value);
     setSearchParams(searchParams);
   };
+
   return (
     <>
       <Tr>
@@ -25,7 +30,7 @@ export function VideoDurationRadio({
             onChange={(value) => {
               handleChange(value as VideoDurationType);
             }}
-            value={searchParams.get('videoDuration') || 'full'}
+            value={videoDuration}
           >
             <Stack direction="row">
               <Radio value="full">Full</Radio>

--- a/app/src/action_object_search/components/VideoDurationRadio.tsx
+++ b/app/src/action_object_search/components/VideoDurationRadio.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import { Radio, RadioGroup, Stack, Td, Th, Tr } from '@chakra-ui/react';
 import {
   SearchParamKey,
-  selectedVideoDurationKey,
+  SELETED_VIDEO_DURATION_KEY,
 } from 'action_object_search/constants';
 
 export type VideoDurationType = 'full' | 'segment';
@@ -19,7 +19,7 @@ export function VideoDurationRadio({
   const handleChange = useCallback(
     (value: VideoDurationType) => {
       setSelectedVideoDuration(value);
-      handleSearchParamsChange(selectedVideoDurationKey, value);
+      handleSearchParamsChange(SELETED_VIDEO_DURATION_KEY, value);
     },
     [setSelectedVideoDuration, handleSearchParamsChange]
   );

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -1,5 +1,5 @@
 import { Grid, GridItem, Link } from '@chakra-ui/react';
-import { VideoQueryType } from 'action_object_search/utils/sparql';
+import { type VideoQueryType } from 'action_object_search/utils/sparql';
 import React from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 

--- a/app/src/action_object_search/constants.ts
+++ b/app/src/action_object_search/constants.ts
@@ -2,13 +2,12 @@ export const TOTAL_VIDEOS_PER_PAGE = 9;
 
 export type SearchParamObjectKey = 'mainObject' | 'targetObject';
 export type SearchParamKey =
-  | 'selectedAction'
-  | 'selectedVideoDuration'
+  | 'action'
+  | 'videoDuration'
   | 'searchResultPage'
   | SearchParamObjectKey;
-export const SELETED_ACTION_KEY: SearchParamKey = 'selectedAction';
+export const ACTION_KEY: SearchParamKey = 'action';
 export const MAIN_OBJECT_KEY: SearchParamKey = 'mainObject';
 export const TARGET_OBJECT_KEY: SearchParamKey = 'targetObject';
-export const SELETED_VIDEO_DURATION_KEY: SearchParamKey =
-  'selectedVideoDuration';
+export const VIDEO_DURATION_KEY: SearchParamKey = 'videoDuration';
 export const SEARCH_RESULT_PAGE_KEY: SearchParamKey = 'searchResultPage';

--- a/app/src/action_object_search/constants.ts
+++ b/app/src/action_object_search/constants.ts
@@ -1,1 +1,13 @@
 export const TOTAL_VIDEOS_PER_PAGE = 9;
+
+export type SearchParamObjectKey = 'mainObject' | 'targetObject';
+export type SearchParamKey =
+  | 'selectedAction'
+  | 'selectedVideoDuration'
+  | 'searchResultPage'
+  | SearchParamObjectKey;
+export const selectedActionKey: SearchParamKey = 'selectedAction';
+export const mainObjectKey: SearchParamKey = 'mainObject';
+export const targetObjectKey: SearchParamKey = 'targetObject';
+export const selectedVideoDurationKey: SearchParamKey = 'selectedVideoDuration';
+export const searchResultPageKey: SearchParamKey = 'searchResultPage';

--- a/app/src/action_object_search/constants.ts
+++ b/app/src/action_object_search/constants.ts
@@ -6,8 +6,9 @@ export type SearchParamKey =
   | 'selectedVideoDuration'
   | 'searchResultPage'
   | SearchParamObjectKey;
-export const selectedActionKey: SearchParamKey = 'selectedAction';
-export const mainObjectKey: SearchParamKey = 'mainObject';
-export const targetObjectKey: SearchParamKey = 'targetObject';
-export const selectedVideoDurationKey: SearchParamKey = 'selectedVideoDuration';
-export const searchResultPageKey: SearchParamKey = 'searchResultPage';
+export const SELETED_ACTION_KEY: SearchParamKey = 'selectedAction';
+export const MAIN_OBJECT_KEY: SearchParamKey = 'mainObject';
+export const TARGET_OBJECT_KEY: SearchParamKey = 'targetObject';
+export const SELETED_VIDEO_DURATION_KEY: SearchParamKey =
+  'selectedVideoDuration';
+export const SEARCH_RESULT_PAGE_KEY: SearchParamKey = 'searchResultPage';


### PR DESCRIPTION
## 変更の概要
- 動画の検索パラメータをクエリパラメータとして保存するように変更しました
## なぜこの変更をするのか
- 検索結果の動画から2DBBOXの表示画面に遷移した場合に、元の検索ページに戻る際に検索内容が全てリセットされることを防ぐためです
## やったこと
- `useSearchParams`を使用して、検索パラメータが変更された際に、それをクエリパラメータに保存する処理を追加しました
- 検索パラメータの初期値として、クエリパラメータが存在する場合にそれを使用する処理を追加しました
## やらないこと
## できるようになること
- 再読み込みやページ遷移を行った際に前回の検索結果が表示されるようになります
## できなくなること
## 動作確認方法
## その他
録画を添付しておりますので、こちらも併せてご確認ください。

https://github.com/user-attachments/assets/f71ae5e5-f2a7-467d-9a93-9e386a9c31de

