### PR TITLE
SceneのSelect要素の追加

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -122,10 +122,15 @@ function ActionObjectSearch(): React.ReactElement {
       }
 
       setVideoCount(
-        await fetchVideoCount(selectedAction, mainObject, targetObject)
+        await fetchVideoCount(
+          selectedAction,
+          mainObject,
+          targetObject,
+          selectedScene
+        )
       );
     })();
-  }, [selectedAction, mainObject, targetObject]);
+  }, [selectedAction, mainObject, targetObject, selectedScene]);
 
   return (
     <ChakraProvider>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -30,7 +30,7 @@ import {
   fetchScene,
   fetchVideo,
   fetchVideoCount,
-  SceneQueryType,
+  type SceneQueryType,
   type VideoQueryType,
 } from 'action_object_search/utils/sparql';
 import FloatingNavigationLink from 'common/components/FloatingNavigationLink';

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -26,6 +26,7 @@ import {
 import {
   type ActionQueryType,
   fetchAction,
+  fetchScene,
   fetchVideo,
   fetchVideoCount,
   type VideoQueryType,
@@ -33,6 +34,7 @@ import {
 import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { SelectScene } from 'action_object_search/components/SelectScene';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -22,6 +22,7 @@ import {
   VIDEO_DURATION_KEY,
   TARGET_OBJECT_KEY,
   TOTAL_VIDEOS_PER_PAGE,
+  SCENE_KEY,
 } from 'action_object_search/constants';
 import {
   type ActionQueryType,
@@ -61,7 +62,9 @@ function ActionObjectSearch(): React.ReactElement {
   const [searchResultPage, setSearchResultPage] = useState<number>(
     Number(searchParams.get(SEARCH_RESULT_PAGE_KEY)) || 1
   );
-  const [selectedScene, setSelectedScene] = useState<string>('');
+  const [selectedScene, setSelectedScene] = useState<string>(
+    searchParams.get(SCENE_KEY) || ''
+  );
 
   const handleSearchParamsChange = useCallback(
     (key: SearchParamKey, value: string) => {

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -29,6 +29,7 @@ import {
   fetchScene,
   fetchVideo,
   fetchVideoCount,
+  SceneQueryType,
   type VideoQueryType,
 } from 'action_object_search/utils/sparql';
 import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
@@ -40,6 +41,7 @@ function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
   const [videos, setVideos] = useState<VideoQueryType[]>([]);
   const [videoCount, setVideoCount] = useState<number>(0);
+  const [scenes, setScenes] = useState<SceneQueryType[]>([]);
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -59,6 +61,7 @@ function ActionObjectSearch(): React.ReactElement {
   const [searchResultPage, setSearchResultPage] = useState<number>(
     Number(searchParams.get(SEARCH_RESULT_PAGE_KEY)) || 1
   );
+  const [selectedScene, setSelectedScene] = useState<string>('');
 
   const handleSearchParamsChange = useCallback(
     (key: SearchParamKey, value: string) => {
@@ -90,9 +93,13 @@ function ActionObjectSearch(): React.ReactElement {
             selectedAction,
             mainObject,
             targetObject,
+            selectedScene,
             TOTAL_VIDEOS_PER_PAGE,
             searchResultPage
           )
+        );
+        setScenes(
+          await fetchScene(selectedAction, mainObject, targetObject, '')
         );
       }
     })();
@@ -100,6 +107,7 @@ function ActionObjectSearch(): React.ReactElement {
     selectedAction,
     mainObject,
     targetObject,
+    selectedScene,
     selectedVideoDuration,
     searchResultPage,
   ]);
@@ -151,6 +159,12 @@ function ActionObjectSearch(): React.ReactElement {
               <VideoDurationRadio
                 selectedVideoDuration={selectedVideoDuration}
                 setSelectedVideoDuration={setSelectedVideoDuration}
+                handleSearchParamsChange={handleSearchParamsChange}
+              />
+              <SelectScene
+                scenes={scenes}
+                selectedScene={selectedScene}
+                setSelectedScene={setSelectedScene}
                 handleSearchParamsChange={handleSearchParamsChange}
               />
             </Tbody>

--- a/app/src/action_object_search/components/SelectScene.tsx
+++ b/app/src/action_object_search/components/SelectScene.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { SceneQueryType } from 'action_object_search/utils/sparql';
-import { SearchParamKey } from 'action_object_search/constants';
+import { SCENE_KEY, SearchParamKey } from 'action_object_search/constants';
 
 type SelectSceneProps = {
   scenes: SceneQueryType[];
@@ -24,7 +24,7 @@ export function SelectScene({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {
       setSelectedScene(event.target.value);
-      handleSearchParamsChange('scene', event.target.value);
+      handleSearchParamsChange(SCENE_KEY, event.target.value);
     },
     [setSelectedScene, handleSearchParamsChange]
   );

--- a/app/src/action_object_search/components/SelectScene.tsx
+++ b/app/src/action_object_search/components/SelectScene.tsx
@@ -19,6 +19,7 @@ export function SelectScene({
     scenes
       .map((scene) => scene.scene.value.split('_').pop())
       .filter((scene) => scene !== undefined)
+      .sort()
   );
 
   const handleChange = useCallback(

--- a/app/src/action_object_search/components/SelectScene.tsx
+++ b/app/src/action_object_search/components/SelectScene.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Select, Td, Th, Tr } from '@chakra-ui/react';
+import { SceneQueryType } from 'action_object_search/utils/sparql';
+
+type SelectSceneProps = {
+  scenes: SceneQueryType[];
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
+};
+export function SelectScene({
+  scenes,
+  searchParams,
+  setSearchParams,
+}: SelectSceneProps): React.ReactElement {
+  const options = new Set(
+    scenes
+      .map((scene) => scene.scene.value.split('_').pop())
+      .filter((scene) => scene !== undefined)
+  );
+  return (
+    <>
+      <Tr>
+        <Th width={60} fontSize="large">
+          Scene
+        </Th>
+        <Td>
+          <Select
+            placeholder="select"
+            value={searchParams.get('scene') || ''}
+            onChange={(e) => {
+              const scene = e.target.value;
+              searchParams.set('scene', scene);
+              setSearchParams(searchParams);
+            }}
+          >
+            {Array.from(options).map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </Select>
+        </Td>
+      </Tr>
+    </>
+  );
+}

--- a/app/src/action_object_search/components/SelectScene.tsx
+++ b/app/src/action_object_search/components/SelectScene.tsx
@@ -1,22 +1,34 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { SceneQueryType } from 'action_object_search/utils/sparql';
+import { SearchParamKey } from 'action_object_search/constants';
 
 type SelectSceneProps = {
   scenes: SceneQueryType[];
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  selectedScene: string;
+  setSelectedScene: (scene: string) => void;
+  handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
 };
 export function SelectScene({
   scenes,
-  searchParams,
-  setSearchParams,
+  selectedScene,
+  setSelectedScene,
+  handleSearchParamsChange,
 }: SelectSceneProps): React.ReactElement {
   const options = new Set(
     scenes
       .map((scene) => scene.scene.value.split('_').pop())
       .filter((scene) => scene !== undefined)
   );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedScene(event.target.value);
+      handleSearchParamsChange('scene', event.target.value);
+    },
+    [setSelectedScene, handleSearchParamsChange]
+  );
+
   return (
     <>
       <Tr>
@@ -26,12 +38,8 @@ export function SelectScene({
         <Td>
           <Select
             placeholder="select"
-            value={searchParams.get('scene') || ''}
-            onChange={(e) => {
-              const scene = e.target.value;
-              searchParams.set('scene', scene);
-              setSearchParams(searchParams);
-            }}
+            value={selectedScene}
+            onChange={handleChange}
           >
             {Array.from(options).map((option) => (
               <option key={option} value={option}>

--- a/app/src/action_object_search/components/SelectScene.tsx
+++ b/app/src/action_object_search/components/SelectScene.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { SceneQueryType } from 'action_object_search/utils/sparql';
-import { SCENE_KEY, SearchParamKey } from 'action_object_search/constants';
+import { type SceneQueryType } from 'action_object_search/utils/sparql';
+import { SCENE_KEY, type SearchParamKey } from 'action_object_search/constants';
 
 type SelectSceneProps = {
   scenes: SceneQueryType[];

--- a/app/src/action_object_search/components/SelectScene.tsx
+++ b/app/src/action_object_search/components/SelectScene.tsx
@@ -15,11 +15,13 @@ export function SelectScene({
   setSelectedScene,
   handleSearchParamsChange,
 }: SelectSceneProps): React.ReactElement {
-  const options = new Set(
-    scenes
-      .map((scene) => scene.scene.value.split('_').pop())
-      .filter((scene) => scene !== undefined)
-      .sort()
+  const options = Array.from(
+    new Set(
+      scenes
+        .map((scene) => scene.scene.value.split('_').pop())
+        .filter((scene) => scene !== undefined)
+        .sort()
+    )
   );
 
   const handleChange = useCallback(
@@ -42,7 +44,7 @@ export function SelectScene({
             value={selectedScene}
             onChange={handleChange}
           >
-            {Array.from(options).map((option) => (
+            {options.map((option) => (
               <option key={option} value={option}>
                 {option}
               </option>

--- a/app/src/action_object_search/constants.ts
+++ b/app/src/action_object_search/constants.ts
@@ -5,9 +5,11 @@ export type SearchParamKey =
   | 'action'
   | 'videoDuration'
   | 'searchResultPage'
+  | 'scene'
   | SearchParamObjectKey;
 export const ACTION_KEY: SearchParamKey = 'action';
 export const MAIN_OBJECT_KEY: SearchParamKey = 'mainObject';
 export const TARGET_OBJECT_KEY: SearchParamKey = 'targetObject';
 export const VIDEO_DURATION_KEY: SearchParamKey = 'videoDuration';
 export const SEARCH_RESULT_PAGE_KEY: SearchParamKey = 'searchResultPage';
+export const SCENE_KEY: SearchParamKey = 'scene';

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -63,8 +63,9 @@ export type VideoCountQueryType = {
 export const fetchVideoCount: (
   action: string,
   mainObject: string,
-  targetObject: string
-) => Promise<number> = async (action, mainObject, targetObject) => {
+  targetObject: string,
+  scene: string
+) => Promise<number> = async (action, mainObject, targetObject, scene) => {
   const query = `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
@@ -80,6 +81,7 @@ export const fetchVideoCount: (
              vh2kg:action <${action}> .
       ?activity vh2kg:hasEvent ?event ;
                 vh2kg:hasVideo ?camera .
+      ${scene !== '' ? `FILTER regex(STR(?camera), "${scene}", "i") .` : ''}
     }
   `;
   const result = (await makeClient().query.select(


### PR DESCRIPTION
## 変更の概要
- SceneのSelect要素を追加しました
## なぜこの変更をするのか
- Scene別の動画や動画セグメントを表示できるようにするためです
## やったこと
- `app/src/action_object_search/components/SelectScene.tsx`を作成しました
- クエリパラメータにSceneを保存するように変更しました
- 動画総数の検索処理を修正して、Sceneを選択した際に検索結果のPaginationが正しく表示されるようにしました
## やらないこと
- `app/src/action_object_search/utils/sparql.ts`にて、`fetchScene()`の引数として`camera`を受け取った際の処理の追加
CameraのSelect要素を作成する際に追記します。
## できるようになること
- Sceneで動画（セグメント）の検索結果を絞り込めるようになります
## できなくなること

## 動作確認方法

## その他
添付の画像と録画も併せてご確認ください。

<img width="1840" alt="Screenshot 2024-11-19 at 17 31 37" src="https://github.com/user-attachments/assets/7b25c2cb-46f0-42e3-a1e3-596e00287b70">


https://github.com/user-attachments/assets/2761c199-c23b-40ac-abe3-da9bf56e28a5

