### PR TITLE
CameraのSelect要素の作成

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -131,6 +131,7 @@ function ActionObjectSearch(): React.ReactElement {
     mainObject,
     targetObject,
     selectedScene,
+    selectedCamera,
     selectedVideoDuration,
     searchResultPage,
   ]);

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -1,6 +1,7 @@
 import {
   ChakraProvider,
   Flex,
+  Select,
   Table,
   TableContainer,
   Tbody,
@@ -26,6 +27,7 @@ import {
 } from 'action_object_search/constants';
 import {
   type ActionQueryType,
+  type CameraQueryType,
   fetchAction,
   fetchScene,
   fetchVideo,
@@ -68,6 +70,7 @@ function ActionObjectSearch(): React.ReactElement {
   const [selectedScene, setSelectedScene] = useState<string>(
     searchParams.get(SCENE_KEY) || ''
   );
+  const [selectedCamera, setSelectedCamera] = useState<string>('');
 
   const handleSearchParamsChange = useCallback(
     (key: SearchParamKey, value: string) => {
@@ -100,12 +103,26 @@ function ActionObjectSearch(): React.ReactElement {
             mainObject,
             targetObject,
             selectedScene,
+            selectedCamera,
             TOTAL_VIDEOS_PER_PAGE,
             searchResultPage
           )
         );
         setScenes(
-          await fetchScene(selectedAction, mainObject, targetObject, '')
+          await fetchScene(
+            selectedAction,
+            mainObject,
+            targetObject,
+            selectedCamera
+          )
+        );
+        setCameras(
+          await fetchCamera(
+            selectedAction,
+            mainObject,
+            targetObject,
+            selectedScene
+          )
         );
       }
     })();
@@ -176,6 +193,12 @@ function ActionObjectSearch(): React.ReactElement {
                 scenes={scenes}
                 selectedScene={selectedScene}
                 setSelectedScene={setSelectedScene}
+                handleSearchParamsChange={handleSearchParamsChange}
+              />
+              <SelectCamera
+                cameras={cameras}
+                selectedCamera={selectedCamera}
+                setSelectedCamera={setSelectedCamera}
                 handleSearchParamsChange={handleSearchParamsChange}
               />
             </Tbody>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -1,7 +1,6 @@
 import {
   ChakraProvider,
   Flex,
-  Select,
   Table,
   TableContainer,
   Tbody,

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -153,11 +153,12 @@ function ActionObjectSearch(): React.ReactElement {
           selectedAction,
           mainObject,
           targetObject,
-          selectedScene
+          selectedScene,
+          selectedCamera
         )
       );
     })();
-  }, [selectedAction, mainObject, targetObject, selectedScene]);
+  }, [selectedAction, mainObject, targetObject, selectedScene, selectedCamera]);
 
   return (
     <ChakraProvider>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -24,6 +24,7 @@ import {
   TARGET_OBJECT_KEY,
   TOTAL_VIDEOS_PER_PAGE,
   SCENE_KEY,
+  CAMERA_KEY,
 } from 'action_object_search/constants';
 import {
   type ActionQueryType,
@@ -70,7 +71,9 @@ function ActionObjectSearch(): React.ReactElement {
   const [selectedScene, setSelectedScene] = useState<string>(
     searchParams.get(SCENE_KEY) || ''
   );
-  const [selectedCamera, setSelectedCamera] = useState<string>('');
+  const [selectedCamera, setSelectedCamera] = useState<string>(
+    searchParams.get(CAMERA_KEY) || ''
+  );
 
   const handleSearchParamsChange = useCallback(
     (key: SearchParamKey, value: string) => {

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -37,12 +37,15 @@ import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { SelectScene } from 'action_object_search/components/SelectScene';
+import { SelectCamera } from 'action_object_search/components/SelectCamera';
+import { fetchCamera } from 'action_object_search/utils/sparql';
 
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
   const [videos, setVideos] = useState<VideoQueryType[]>([]);
   const [videoCount, setVideoCount] = useState<number>(0);
   const [scenes, setScenes] = useState<SceneQueryType[]>([]);
+  const [cameras, setCameras] = useState<CameraQueryType[]>([]);
 
   const [searchParams, setSearchParams] = useSearchParams();
 

--- a/app/src/action_object_search/components/SelectCamera.tsx
+++ b/app/src/action_object_search/components/SelectCamera.tsx
@@ -1,22 +1,36 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
 import { CameraQueryType } from 'action_object_search/utils/sparql';
+import { CAMERA_KEY, SearchParamKey } from 'action_object_search/constants';
 
 type SelectCameraProps = {
   cameras: CameraQueryType[];
-  searchParams: URLSearchParams;
-  setSearchParams: (searchParams: URLSearchParams) => void;
+  selectedCamera: string;
+  setSelectedCamera: (camera: string) => void;
+  handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
 };
 export function SelectCamera({
   cameras,
-  searchParams,
-  setSearchParams,
+  selectedCamera,
+  setSelectedCamera,
+  handleSearchParamsChange,
 }: SelectCameraProps): React.ReactElement {
-  const options = new Set(
-    cameras
-      .map((camera) => camera.camera.value.split('_').pop())
-      .filter((camera) => camera !== undefined)
+  const options = Array.from(
+    new Set(
+      cameras
+        .map((camera) => camera.camera.value.split('_').pop())
+        .filter((camera) => camera !== undefined)
+    )
   );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedCamera(event.target.value);
+      handleSearchParamsChange(CAMERA_KEY, event.target.value);
+    },
+    [setSelectedCamera, handleSearchParamsChange]
+  );
+
   return (
     <>
       <Tr>
@@ -26,14 +40,10 @@ export function SelectCamera({
         <Td>
           <Select
             placeholder="select"
-            value={searchParams.get('camera') || ''}
-            onChange={(e) => {
-              const camera = e.target.value;
-              searchParams.set('camera', camera);
-              setSearchParams(searchParams);
-            }}
+            value={selectedCamera}
+            onChange={handleChange}
           >
-            {Array.from(options).map((option) => (
+            {options.map((option) => (
               <option key={option} value={option}>
                 {option}
               </option>

--- a/app/src/action_object_search/components/SelectCamera.tsx
+++ b/app/src/action_object_search/components/SelectCamera.tsx
@@ -20,6 +20,7 @@ export function SelectCamera({
       cameras
         .map((camera) => camera.camera.value.split('_').pop())
         .filter((camera) => camera !== undefined)
+        .sort()
     )
   );
 

--- a/app/src/action_object_search/components/SelectCamera.tsx
+++ b/app/src/action_object_search/components/SelectCamera.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Select, Td, Th, Tr } from '@chakra-ui/react';
+import { CameraQueryType } from 'action_object_search/utils/sparql';
+
+type SelectCameraProps = {
+  cameras: CameraQueryType[];
+  searchParams: URLSearchParams;
+  setSearchParams: (searchParams: URLSearchParams) => void;
+};
+export function SelectCamera({
+  cameras,
+  searchParams,
+  setSearchParams,
+}: SelectCameraProps): React.ReactElement {
+  const options = new Set(
+    cameras
+      .map((camera) => camera.camera.value.split('_').pop())
+      .filter((camera) => camera !== undefined)
+  );
+  return (
+    <>
+      <Tr>
+        <Th width={60} fontSize="large">
+          Camera
+        </Th>
+        <Td>
+          <Select
+            placeholder="select"
+            value={searchParams.get('camera') || ''}
+            onChange={(e) => {
+              const camera = e.target.value;
+              searchParams.set('camera', camera);
+              setSearchParams(searchParams);
+            }}
+          >
+            {Array.from(options).map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </Select>
+        </Td>
+      </Tr>
+    </>
+  );
+}

--- a/app/src/action_object_search/components/SelectCamera.tsx
+++ b/app/src/action_object_search/components/SelectCamera.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback } from 'react';
 import { Select, Td, Th, Tr } from '@chakra-ui/react';
-import { CameraQueryType } from 'action_object_search/utils/sparql';
-import { CAMERA_KEY, SearchParamKey } from 'action_object_search/constants';
+import { type CameraQueryType } from 'action_object_search/utils/sparql';
+import {
+  CAMERA_KEY,
+  type SearchParamKey,
+} from 'action_object_search/constants';
 
 type SelectCameraProps = {
   cameras: CameraQueryType[];

--- a/app/src/action_object_search/constants.ts
+++ b/app/src/action_object_search/constants.ts
@@ -6,6 +6,7 @@ export type SearchParamKey =
   | 'videoDuration'
   | 'searchResultPage'
   | 'scene'
+  | 'camera'
   | SearchParamObjectKey;
 export const ACTION_KEY: SearchParamKey = 'action';
 export const MAIN_OBJECT_KEY: SearchParamKey = 'mainObject';
@@ -13,3 +14,4 @@ export const TARGET_OBJECT_KEY: SearchParamKey = 'targetObject';
 export const VIDEO_DURATION_KEY: SearchParamKey = 'videoDuration';
 export const SEARCH_RESULT_PAGE_KEY: SearchParamKey = 'searchResultPage';
 export const SCENE_KEY: SearchParamKey = 'scene';
+export const CAMERA_KEY: SearchParamKey = 'camera';

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -67,8 +67,15 @@ export const fetchVideoCount: (
   action: string,
   mainObject: string,
   targetObject: string,
-  scene: string
-) => Promise<number> = async (action, mainObject, targetObject, scene) => {
+  scene: string,
+  camera: string
+) => Promise<number> = async (
+  action,
+  mainObject,
+  targetObject,
+  scene,
+  camera
+) => {
   const query = `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
@@ -85,6 +92,7 @@ export const fetchVideoCount: (
       ?activity vh2kg:hasEvent ?event ;
                 vh2kg:hasVideo ?camera .
       ${scene !== '' ? `FILTER regex(STR(?camera), "${scene}", "i") .` : ''}
+      ${camera !== '' ? `FILTER regex(STR(?camera), "${camera}", "i") .` : ''}
     }
   `;
   const result = (await makeClient().query.select(


### PR DESCRIPTION
## 変更の概要
- CameraのSelect要素を作成しました
## なぜこの変更をするのか
- Cameraを条件として動画や動画セグメントを検索できるようにするためです
## やったこと
- CameraのSelect要素を`app/src/action_object_search/components/SelectCamera.tsx`に作成しました
- クエリパラメータにCameraを追加しました
- Cameraが指定されている場合、SceneのSelect要素はそれを含むSceneのみを表示するようにしました
- 動画の総数の検索にCameraを使用するようにして、Cameraを選択してもPaginationが正確に表示されるように変更しました
## やらないこと
## できるようになること
- 指定したCameraを含む動画や動画セグメントのみを表示できるようになります
## できなくなること
## 動作確認方法
## その他
添付の画像と録画のご確認もよろしくお願いいたします。

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/e0444185-f12e-4d98-b35f-7f98db09982a">


https://github.com/user-attachments/assets/28bba30a-ef03-4560-b3bf-538acd20a012

