### PR TITLE
動画セグメントの検索機能の追加

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -174,11 +174,19 @@ function ActionObjectSearch(): React.ReactElement {
           mainObject,
           targetObject,
           selectedScene,
-          selectedCamera
+          selectedCamera,
+          selectedVideoDuration
         )
       );
     })();
-  }, [selectedAction, mainObject, targetObject, selectedScene, selectedCamera]);
+  }, [
+    selectedAction,
+    mainObject,
+    targetObject,
+    selectedScene,
+    selectedCamera,
+    selectedVideoDuration,
+  ]);
 
   return (
     <ChakraProvider>

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -32,8 +32,10 @@ import {
   fetchScene,
   fetchVideo,
   fetchVideoCount,
+  fetchVideoSegment,
   type SceneQueryType,
   type VideoQueryType,
+  type VideoSegmentQueryType,
 } from 'action_object_search/utils/sparql';
 import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -45,6 +47,9 @@ import { fetchCamera } from 'action_object_search/utils/sparql';
 function ActionObjectSearch(): React.ReactElement {
   const [actions, setActions] = useState<ActionQueryType[]>([]);
   const [videos, setVideos] = useState<VideoQueryType[]>([]);
+  const [videoSegments, setVideoSegments] = useState<VideoSegmentQueryType[]>(
+    []
+  );
   const [videoCount, setVideoCount] = useState<number>(0);
   const [scenes, setScenes] = useState<SceneQueryType[]>([]);
   const [cameras, setCameras] = useState<CameraQueryType[]>([]);
@@ -98,34 +103,50 @@ function ActionObjectSearch(): React.ReactElement {
     }
 
     (async () => {
-      if (selectedVideoDuration === 'full') {
-        setVideos(
-          await fetchVideo(
-            selectedAction,
-            mainObject,
-            targetObject,
-            selectedScene,
-            selectedCamera,
-            TOTAL_VIDEOS_PER_PAGE,
-            searchResultPage
-          )
-        );
-        setScenes(
-          await fetchScene(
-            selectedAction,
-            mainObject,
-            targetObject,
-            selectedCamera
-          )
-        );
-        setCameras(
-          await fetchCamera(
-            selectedAction,
-            mainObject,
-            targetObject,
-            selectedScene
-          )
-        );
+      setScenes(
+        await fetchScene(
+          selectedAction,
+          mainObject,
+          targetObject,
+          selectedCamera
+        )
+      );
+      setCameras(
+        await fetchCamera(
+          selectedAction,
+          mainObject,
+          targetObject,
+          selectedScene
+        )
+      );
+
+      switch (selectedVideoDuration) {
+        case 'full':
+          setVideos(
+            await fetchVideo(
+              selectedAction,
+              mainObject,
+              targetObject,
+              selectedScene,
+              selectedCamera,
+              TOTAL_VIDEOS_PER_PAGE,
+              searchResultPage
+            )
+          );
+          break;
+        case 'segment':
+          setVideoSegments(
+            await fetchVideoSegment(
+              selectedAction,
+              mainObject,
+              targetObject,
+              selectedScene,
+              selectedCamera,
+              TOTAL_VIDEOS_PER_PAGE,
+              searchResultPage
+            )
+          );
+          break;
       }
     })();
   }, [

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -79,6 +79,8 @@ function ActionObjectSearch(): React.ReactElement {
     searchParams.get(CAMERA_KEY) || ''
   );
 
+  const isRequiredParamsEmpty = selectedAction === '' || mainObject === '';
+
   const handleSearchParamsChange = useCallback(
     (key: SearchParamKey, value: string) => {
       const newSearchParams = new URLSearchParams(searchParams);
@@ -95,10 +97,7 @@ function ActionObjectSearch(): React.ReactElement {
   }, []);
 
   useEffect(() => {
-    if (selectedAction === '') {
-      return;
-    }
-    if (mainObject === '') {
+    if (isRequiredParamsEmpty) {
       return;
     }
 
@@ -111,6 +110,15 @@ function ActionObjectSearch(): React.ReactElement {
           selectedCamera
         )
       );
+    })();
+  }, [selectedAction, mainObject, targetObject, selectedCamera]);
+
+  useEffect(() => {
+    if (isRequiredParamsEmpty) {
+      return;
+    }
+
+    (async () => {
       setCameras(
         await fetchCamera(
           selectedAction,
@@ -119,7 +127,15 @@ function ActionObjectSearch(): React.ReactElement {
           selectedScene
         )
       );
+    })();
+  }, [selectedAction, mainObject, targetObject, selectedScene]);
 
+  useEffect(() => {
+    if (isRequiredParamsEmpty) {
+      return;
+    }
+
+    (async () => {
       switch (selectedVideoDuration) {
         case 'full':
           setVideos(
@@ -160,14 +176,11 @@ function ActionObjectSearch(): React.ReactElement {
   ]);
 
   useEffect(() => {
-    (async () => {
-      if (selectedAction === '') {
-        return;
-      }
-      if (mainObject === '') {
-        return;
-      }
+    if (isRequiredParamsEmpty) {
+      return;
+    }
 
+    (async () => {
       setVideoCount(
         await fetchVideoCount(
           selectedAction,

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -229,7 +229,10 @@ function ActionObjectSearch(): React.ReactElement {
             </Tbody>
           </Table>
         </TableContainer>
-        <VideoGrid videos={videos} />
+        {selectedVideoDuration === 'full' && <VideoGrid videos={videos} />}
+        {selectedVideoDuration === 'segment' && (
+          <VideoGrid videos={videoSegments} isSegment={true} />
+        )}
         <Pagination
           searchResultPage={searchResultPage}
           setSearchResultPage={setSearchResultPage}

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -79,7 +79,7 @@ function ActionObjectSearch(): React.ReactElement {
     searchParams.get(CAMERA_KEY) || ''
   );
 
-  const isRequiredParamsEmpty = selectedAction === '' || mainObject === '';
+  const isAnyRequiredParamsEmpty = selectedAction === '' || mainObject === '';
 
   const handleSearchParamsChange = useCallback(
     (key: SearchParamKey, value: string) => {
@@ -97,7 +97,7 @@ function ActionObjectSearch(): React.ReactElement {
   }, []);
 
   useEffect(() => {
-    if (isRequiredParamsEmpty) {
+    if (isAnyRequiredParamsEmpty) {
       return;
     }
 
@@ -114,7 +114,7 @@ function ActionObjectSearch(): React.ReactElement {
   }, [selectedAction, mainObject, targetObject, selectedCamera]);
 
   useEffect(() => {
-    if (isRequiredParamsEmpty) {
+    if (isAnyRequiredParamsEmpty) {
       return;
     }
 
@@ -131,7 +131,7 @@ function ActionObjectSearch(): React.ReactElement {
   }, [selectedAction, mainObject, targetObject, selectedScene]);
 
   useEffect(() => {
-    if (isRequiredParamsEmpty) {
+    if (isAnyRequiredParamsEmpty) {
       return;
     }
 
@@ -176,7 +176,7 @@ function ActionObjectSearch(): React.ReactElement {
   ]);
 
   useEffect(() => {
-    if (isRequiredParamsEmpty) {
+    if (isAnyRequiredParamsEmpty) {
       return;
     }
 

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -252,7 +252,7 @@ function ActionObjectSearch(): React.ReactElement {
         </TableContainer>
         {selectedVideoDuration === 'full' && <VideoGrid videos={videos} />}
         {selectedVideoDuration === 'segment' && (
-          <VideoGrid videos={videoSegments} isSegment={true} />
+          <VideoGrid videos={videoSegments} />
         )}
         <Pagination
           searchResultPage={searchResultPage}

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -20,23 +20,25 @@ export function VideoGrid({ videos }: VideoGridProps): React.ReactElement {
   return (
     <Grid templateColumns="repeat(3, 1fr)" gap={4}>
       {videos.map((video) => {
-        const isVideoSegment = 'videoSegment' in video;
+        const hasVideoSegment = 'videoSegment' in video;
         return (
           <GridItem
-            key={isVideoSegment ? video.videoSegment.value : video.camera.value}
+            key={
+              hasVideoSegment ? video.videoSegment.value : video.camera.value
+            }
             p={2}
             border="1px"
             borderColor="gray.200"
             rounded="xl"
           >
             <video
-              src={`data:video/mp4;base64,${video.base64Video.value}${isVideoSegment ? getVideoDurationAsMediaFragment(video) : ''}`}
+              src={`data:video/mp4;base64,${video.base64Video.value}${hasVideoSegment ? getVideoDurationAsMediaFragment(video) : ''}`}
               controls
               width="100%"
               height="auto"
             />
             <Link as={ReactRouterLink} to={``} state={{}}>
-              {isVideoSegment
+              {hasVideoSegment
                 ? video.videoSegment.value.split('/').pop()
                 : video.camera.value.split('/').pop()}
             </Link>

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -13,62 +13,36 @@ function getVideoDurationAsMediaFragment(video: VideoSegmentQueryType) {
   return `#t=${start},${end}`;
 }
 
-type VideoGridProps =
-  | {
-      videos: VideoQueryType[];
-    }
-  | {
-      videos: VideoSegmentQueryType[];
-      isSegment: boolean;
-    };
-export function VideoGrid(props: VideoGridProps): React.ReactElement {
-  if ('isSegment' in props) {
-    return (
-      <Grid templateColumns="repeat(3, 1fr)" gap={4}>
-        {props.videos.map((video) => (
+type VideoGridProps = {
+  videos: VideoQueryType[] | VideoSegmentQueryType[];
+};
+export function VideoGrid({ videos }: VideoGridProps): React.ReactElement {
+  return (
+    <Grid templateColumns="repeat(3, 1fr)" gap={4}>
+      {videos.map((video) => {
+        const isVideoSegment = 'videoSegment' in video;
+        return (
           <GridItem
-            key={video.videoSegment.value}
+            key={isVideoSegment ? video.videoSegment.value : video.camera.value}
             p={2}
             border="1px"
             borderColor="gray.200"
             rounded="xl"
           >
             <video
-              src={`data:video/mp4;base64,${video.base64Video.value}${getVideoDurationAsMediaFragment(video)}`}
+              src={`data:video/mp4;base64,${video.base64Video.value}${isVideoSegment ? getVideoDurationAsMediaFragment(video) : ''}`}
               controls
               width="100%"
               height="auto"
             />
             <Link as={ReactRouterLink} to={``} state={{}}>
-              {video.videoSegment.value.split('/').pop()}
+              {isVideoSegment
+                ? video.videoSegment.value.split('/').pop()
+                : video.camera.value.split('/').pop()}
             </Link>
           </GridItem>
-        ))}
-      </Grid>
-    );
-  } else {
-    return (
-      <Grid templateColumns="repeat(3, 1fr)" gap={4}>
-        {props.videos.map((video) => (
-          <GridItem
-            key={video.camera.value}
-            p={2}
-            border="1px"
-            borderColor="gray.200"
-            rounded="xl"
-          >
-            <video
-              src={`data:video/mp4;base64,${video.base64Video.value}`}
-              controls
-              width="100%"
-              height="auto"
-            />
-            <Link as={ReactRouterLink} to={``} state={{}}>
-              {video.camera.value.split('/').pop()}
-            </Link>
-          </GridItem>
-        ))}
-      </Grid>
-    );
-  }
+        );
+      })}
+    </Grid>
+  );
 }

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -6,6 +6,13 @@ import {
 import React from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 
+function getVideoDurationAsMediaFragment(video: VideoSegmentQueryType) {
+  const frameRate = Number(video.frameRate.value);
+  const start = Math.floor(Number(video.startFrame.value) / frameRate);
+  const end = Math.floor(Number(video.endFrame.value) / frameRate);
+  return `#t=${start},${end}`;
+}
+
 type VideoGridProps = {
   videos: VideoQueryType[] | VideoSegmentQueryType[];
   isSegment?: boolean;
@@ -14,13 +21,6 @@ export function VideoGrid({
   videos,
   isSegment = false,
 }: VideoGridProps): React.ReactElement {
-  const getVideoDurationAsMediaFragment = (video: VideoSegmentQueryType) => {
-    const frameRate = Number(video.frameRate.value);
-    const start = Math.floor(Number(video.startFrame.value) / frameRate);
-    const end = Math.floor(Number(video.endFrame.value) / frameRate);
-    return `#t=${start},${end}`;
-  };
-
   return (
     <Grid templateColumns="repeat(3, 1fr)" gap={4}>
       {videos.map((video) => (

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -13,43 +13,62 @@ function getVideoDurationAsMediaFragment(video: VideoSegmentQueryType) {
   return `#t=${start},${end}`;
 }
 
-type VideoGridProps = {
-  videos: VideoQueryType[] | VideoSegmentQueryType[];
-  isSegment?: boolean;
-};
-export function VideoGrid({
-  videos,
-  isSegment = false,
-}: VideoGridProps): React.ReactElement {
-  return (
-    <Grid templateColumns="repeat(3, 1fr)" gap={4}>
-      {videos.map((video) => (
-        <GridItem
-          key={
-            isSegment
-              ? (video as VideoSegmentQueryType).videoSegment.value
-              : (video as VideoQueryType).camera.value
-          }
-          p={2}
-          border="1px"
-          borderColor="gray.200"
-          rounded="xl"
-        >
-          <video
-            src={`data:video/mp4;base64,${video.base64Video.value}${isSegment ? getVideoDurationAsMediaFragment(video as VideoSegmentQueryType) : ''}`}
-            controls
-            width="100%"
-            height="auto"
-          />
-          <Link as={ReactRouterLink} to={``} state={{}}>
-            {isSegment
-              ? (video as VideoSegmentQueryType).videoSegment.value
-                  .split('/')
-                  .pop()
-              : (video as VideoQueryType).camera.value.split('/').pop()}
-          </Link>
-        </GridItem>
-      ))}
-    </Grid>
-  );
+type VideoGridProps =
+  | {
+      videos: VideoQueryType[];
+    }
+  | {
+      videos: VideoSegmentQueryType[];
+      isSegment: boolean;
+    };
+export function VideoGrid(props: VideoGridProps): React.ReactElement {
+  if ('isSegment' in props) {
+    return (
+      <Grid templateColumns="repeat(3, 1fr)" gap={4}>
+        {props.videos.map((video) => (
+          <GridItem
+            key={video.videoSegment.value}
+            p={2}
+            border="1px"
+            borderColor="gray.200"
+            rounded="xl"
+          >
+            <video
+              src={`data:video/mp4;base64,${video.base64Video.value}${getVideoDurationAsMediaFragment(video)}`}
+              controls
+              width="100%"
+              height="auto"
+            />
+            <Link as={ReactRouterLink} to={``} state={{}}>
+              {video.videoSegment.value.split('/').pop()}
+            </Link>
+          </GridItem>
+        ))}
+      </Grid>
+    );
+  } else {
+    return (
+      <Grid templateColumns="repeat(3, 1fr)" gap={4}>
+        {props.videos.map((video) => (
+          <GridItem
+            key={video.camera.value}
+            p={2}
+            border="1px"
+            borderColor="gray.200"
+            rounded="xl"
+          >
+            <video
+              src={`data:video/mp4;base64,${video.base64Video.value}`}
+              controls
+              width="100%"
+              height="auto"
+            />
+            <Link as={ReactRouterLink} to={``} state={{}}>
+              {video.camera.value.split('/').pop()}
+            </Link>
+          </GridItem>
+        ))}
+      </Grid>
+    );
+  }
 }

--- a/app/src/action_object_search/components/VideoGrid.tsx
+++ b/app/src/action_object_search/components/VideoGrid.tsx
@@ -1,30 +1,52 @@
 import { Grid, GridItem, Link } from '@chakra-ui/react';
-import { type VideoQueryType } from 'action_object_search/utils/sparql';
+import {
+  type VideoSegmentQueryType,
+  type VideoQueryType,
+} from 'action_object_search/utils/sparql';
 import React from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 
 type VideoGridProps = {
-  videos: VideoQueryType[];
+  videos: VideoQueryType[] | VideoSegmentQueryType[];
+  isSegment?: boolean;
 };
-export function VideoGrid({ videos }: VideoGridProps): React.ReactElement {
+export function VideoGrid({
+  videos,
+  isSegment = false,
+}: VideoGridProps): React.ReactElement {
+  const getVideoDurationAsMediaFragment = (video: VideoSegmentQueryType) => {
+    const frameRate = Number(video.frameRate.value);
+    const start = Math.floor(Number(video.startFrame.value) / frameRate);
+    const end = Math.floor(Number(video.endFrame.value) / frameRate);
+    return `#t=${start},${end}`;
+  };
+
   return (
     <Grid templateColumns="repeat(3, 1fr)" gap={4}>
       {videos.map((video) => (
         <GridItem
-          key={video.camera.value}
+          key={
+            isSegment
+              ? (video as VideoSegmentQueryType).videoSegment.value
+              : (video as VideoQueryType).camera.value
+          }
           p={2}
           border="1px"
           borderColor="gray.200"
           rounded="xl"
         >
           <video
-            src={`data:video/mp4;base64,${video.base64Video.value}`}
+            src={`data:video/mp4;base64,${video.base64Video.value}${isSegment ? getVideoDurationAsMediaFragment(video as VideoSegmentQueryType) : ''}`}
             controls
             width="100%"
             height="auto"
           />
           <Link as={ReactRouterLink} to={``} state={{}}>
-            {video.camera.value.split('/').pop()}
+            {isSegment
+              ? (video as VideoSegmentQueryType).videoSegment.value
+                  .split('/')
+                  .pop()
+              : (video as VideoQueryType).camera.value.split('/').pop()}
           </Link>
         </GridItem>
       ))}

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -1,5 +1,6 @@
 import { NamedNode } from 'rdf-js';
 import { makeClient } from 'common/utils/sparql';
+import { type VideoDurationType } from 'action_object_search/components/VideoDurationRadio';
 
 export type ActionQueryType = {
   action: NamedNode;
@@ -122,18 +123,21 @@ export const fetchVideoCount: (
   mainObject: string,
   targetObject: string,
   scene: string,
-  camera: string
+  camera: string,
+  videoDuration: VideoDurationType
 ) => Promise<number> = async (
   action,
   mainObject,
   targetObject,
   scene,
-  camera
+  camera,
+  videoDuration
 ) => {
   const query = `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
     PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
-    SELECT (COUNT(DISTINCT ?camera) AS ?videoCount) WHERE {
+    SELECT (COUNT(DISTINCT ${videoDuration === 'full' ? '?camera' : '?videoSegment'}) AS ?videoCount) WHERE {
       ?mainObject rdfs:label ?mainObjectLabel FILTER regex(?mainObjectLabel, "${mainObject}", "i") .
       ${
         targetObject !== ''
@@ -142,6 +146,7 @@ export const fetchVideoCount: (
       }
       ?event vh2kg:mainObject ?mainObject ;
              ${targetObject !== '' ? 'vh2kg:targetObject ?targetObject ;' : ''}
+             ${videoDuration === 'segment' ? 'vh2kg:hasVideoSegment ?videoSegment ;' : ''}
              vh2kg:action <${action}> .
       ?activity vh2kg:hasEvent ?event ;
                 vh2kg:hasVideo ?camera .

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -60,6 +60,60 @@ export const fetchVideo: (
   return result;
 };
 
+export type VideoSegmentQueryType = {
+  videoSegment: NamedNode;
+  base64Video: NamedNode;
+  frameRate: NamedNode;
+  startFrame: NamedNode;
+  endFrame: NamedNode;
+};
+export const fetchVideoSegment: (
+  action: string,
+  mainObject: string,
+  targetObject: string,
+  scene: string,
+  camera: string,
+  limit: number,
+  page: number
+) => Promise<VideoSegmentQueryType[]> = async (
+  action,
+  mainObject,
+  targetObject,
+  scene,
+  camera,
+  limit,
+  page
+) => {
+  const query = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    SELECT DISTINCT ?videoSegment ?base64Video ?frameRate ?startFrame ?endFrame WHERE {
+      ?mainObject rdfs:label ?mainObjectLabel FILTER regex(?mainObjectLabel, "${mainObject}", "i") .
+      ${
+        targetObject !== ''
+          ? `?targetObject rdfs:label ?targetObjectLabel FILTER regex(?targetObjectLabel, "${targetObject}", "i") .`
+          : ''
+      }
+      ?event vh2kg:mainObject ?mainObject ;
+             ${targetObject !== '' ? 'vh2kg:targetObject ?targetObject ;' : ''}
+             vh2kg:action <${action}> ;
+             vh2kg:hasVideoSegment ?videoSegment .
+      ?videoSegment vh2kg:hasStartFrame ?startFrame ;
+                    vh2kg:hasEndFrame ?endFrame .
+      ?camera mssn:hasMediaSegment ?videoSegment ;
+              vh2kg:video ?base64Video ;
+              vh2kg:frameRate ?frameRate .
+      ${scene !== '' ? `FILTER regex(STR(?camera), "${scene}", "i") .` : ''}
+      ${camera !== '' ? `FILTER regex(STR(?camera), "${camera}", "i") .` : ''}
+    } ORDER BY asc(?videoSegment) LIMIT ${limit} OFFSET ${limit * (page - 1)}`;
+
+  const result = (await makeClient().query.select(
+    query
+  )) as VideoSegmentQueryType[];
+  return result;
+};
+
 export type VideoCountQueryType = {
   videoCount: NamedNode;
 };

--- a/app/src/action_object_search/utils/sparql.ts
+++ b/app/src/action_object_search/utils/sparql.ts
@@ -150,6 +150,7 @@ export const fetchVideoCount: (
              vh2kg:action <${action}> .
       ?activity vh2kg:hasEvent ?event ;
                 vh2kg:hasVideo ?camera .
+      ${videoDuration === 'segment' ? '?camera mssn:hasMediaSegment ?videoSegment .' : ''}
       ${scene !== '' ? `FILTER regex(STR(?camera), "${scene}", "i") .` : ''}
       ${camera !== '' ? `FILTER regex(STR(?camera), "${camera}", "i") .` : ''}
     }


### PR DESCRIPTION
## 変更の概要
- 動画セグメントを検索できる機能を追加しました
## なぜこの変更をするのか
- 検索条件の動作・オブジェクトを含む動画セグメントを表示できるようにするためです
## やったこと
- `app/src/action_object_search/components/VideoGrid.tsx`で引数として動画の他に動画セグメントのクエリ結果を受け取れるように変更
- `app/src/action_object_search/utils/sparql.ts`で動画セグメントを検索するクエリの追加
- `app/src/action_object_search/ActionObjectSearch.tsx`で`selectedVideoDuration`に応じて動画・動画セグメントの表示を切り替える機能を追加
## やらないこと
## できるようになること
- 動画セグメントを検索することができるようになります
## できなくなること
## 動作確認方法
## その他
添付のスクリーンショットと画面録画のご確認もよろしくお願いいたします。

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/734b3d67-342a-42fe-8751-f83199a45a96">


https://github.com/user-attachments/assets/fe8d218b-776a-4113-aa85-df5506f464fd


