### PR TITLE
Paginationの修正

### DIFF
--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -181,16 +181,20 @@ function ActionObjectSearch(): React.ReactElement {
     }
 
     (async () => {
-      setVideoCount(
-        await fetchVideoCount(
-          selectedAction,
-          mainObject,
-          targetObject,
-          selectedScene,
-          selectedCamera,
-          selectedVideoDuration
-        )
+      const newVideoCount = await fetchVideoCount(
+        selectedAction,
+        mainObject,
+        targetObject,
+        selectedScene,
+        selectedCamera,
+        selectedVideoDuration
       );
+      setVideoCount(newVideoCount);
+
+      if ((searchResultPage - 1) * TOTAL_VIDEOS_PER_PAGE >= newVideoCount) {
+        setSearchResultPage(1);
+        handleSearchParamsChange(SEARCH_RESULT_PAGE_KEY, '1');
+      }
     })();
   }, [
     selectedAction,

--- a/app/src/action_object_search/ActionObjectSearch.tsx
+++ b/app/src/action_object_search/ActionObjectSearch.tsx
@@ -38,7 +38,7 @@ import {
   type VideoSegmentQueryType,
 } from 'action_object_search/utils/sparql';
 import FloatingNavigationLink from 'common/components/FloatingNavigationLink';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { SelectScene } from 'action_object_search/components/SelectScene';
 import { SelectCamera } from 'action_object_search/components/SelectCamera';
@@ -78,6 +78,8 @@ function ActionObjectSearch(): React.ReactElement {
   const [selectedCamera, setSelectedCamera] = useState<string>(
     searchParams.get(CAMERA_KEY) || ''
   );
+
+  const isFirstRender = useRef(true);
 
   const isAnyRequiredParamsEmpty = selectedAction === '' || mainObject === '';
 
@@ -181,21 +183,24 @@ function ActionObjectSearch(): React.ReactElement {
     }
 
     (async () => {
-      const newVideoCount = await fetchVideoCount(
-        selectedAction,
-        mainObject,
-        targetObject,
-        selectedScene,
-        selectedCamera,
-        selectedVideoDuration
+      setVideoCount(
+        await fetchVideoCount(
+          selectedAction,
+          mainObject,
+          targetObject,
+          selectedScene,
+          selectedCamera,
+          selectedVideoDuration
+        )
       );
-      setVideoCount(newVideoCount);
-
-      if ((searchResultPage - 1) * TOTAL_VIDEOS_PER_PAGE >= newVideoCount) {
-        setSearchResultPage(1);
-        handleSearchParamsChange(SEARCH_RESULT_PAGE_KEY, '1');
-      }
     })();
+
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setSearchResultPage(1);
+    handleSearchParamsChange(SEARCH_RESULT_PAGE_KEY, '1');
   }, [
     selectedAction,
     mainObject,


### PR DESCRIPTION
## 変更の概要
- Pagination要素にて、検索条件が変更された場合に1ページ目へ戻るように修正
## なぜこの変更をするのか
- 検索条件が変更されても、以前の検索結果にて表示していたページを表示する不具合の修正のためです
## やったこと
- 検索結果が更新される度に1ページ目へ戻る処理を追加しました。
## やらないこと
## できるようになること
## できなくなること
## 動作確認方法
## その他
- 実装上の懸念点
ページの初回読み込みの際に`useEffect`が実行されてしまいクエリパラメータで指定されたページから移動してしまいます。これを防止するために、初回読み込みであるかを判定するための`useRef`を使用しています。
こちらについてより良い解決方法があればご教示いただけますと幸いです。

また、添付の録画を併せてご確認ください。

https://github.com/user-attachments/assets/2ee3281b-fe70-48e1-b729-9a930373e776

