### PR TITLE
Add 2dbbox page

### DIFF
--- a/app/src/components/action_object_search/Pagination.tsx
+++ b/app/src/components/action_object_search/Pagination.tsx
@@ -1,21 +1,20 @@
 import { Button, ButtonGroup, HStack } from '@chakra-ui/react';
-import {
-  type SearchParamKey,
-  SEARCH_RESULT_PAGE_KEY,
-} from 'constants/action_object_search/constants';
+import { type SearchParamKey } from 'constants/action_object_search/constants';
 import React, { useCallback, useState } from 'react';
 
 type PaginationProps = {
-  searchResultPage: number;
-  setSearchResultPage: (searchResultPage: number) => void;
+  pageState: number;
+  setPageState: (searchResultPage: number) => void;
+  pageKey: SearchParamKey;
   handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
   totalElements: number;
   totalElementsPerPage: number;
   totalDisplayablePages?: number;
 };
 export function Pagination({
-  searchResultPage,
-  setSearchResultPage,
+  pageState,
+  setPageState,
+  pageKey,
   handleSearchParamsChange,
   totalElements,
   totalElementsPerPage,
@@ -38,10 +37,10 @@ export function Pagination({
       if (page === undefined) {
         return;
       }
-      setSearchResultPage(Number(page));
-      handleSearchParamsChange(SEARCH_RESULT_PAGE_KEY, page);
+      setPageState(Number(page));
+      handleSearchParamsChange(pageKey, page);
     },
-    [setSearchResultPage, handleSearchParamsChange]
+    [handleSearchParamsChange, pageKey, setPageState]
   );
 
   const hasPreviousPage = displayedPagesStart !== 1;
@@ -99,7 +98,7 @@ export function Pagination({
             data-page={pageNumber}
             onClick={handlePageNumberButtonClick}
             width={'50px'}
-            colorScheme={pageNumber === searchResultPage ? 'blue' : 'gray'}
+            colorScheme={pageNumber === pageState ? 'blue' : 'gray'}
           >
             {pageNumber}
           </Button>

--- a/app/src/components/action_object_search/Pagination.tsx
+++ b/app/src/components/action_object_search/Pagination.tsx
@@ -4,23 +4,23 @@ import React, { useCallback, useState } from 'react';
 
 type PaginationProps = {
   pageState: number;
-  setPageState: (searchResultPage: number) => void;
-  pageKey: SearchParamKey;
+  setPageState: (pageNumber: number) => void;
+  searchParamPageKey: SearchParamKey;
   handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
   totalElements: number;
-  totalElementsPerPage: number;
+  displayedElementsPerPage: number;
   totalDisplayablePages?: number;
 };
 export function Pagination({
   pageState,
   setPageState,
-  pageKey,
+  searchParamPageKey,
   handleSearchParamsChange,
   totalElements,
-  totalElementsPerPage,
+  displayedElementsPerPage,
   totalDisplayablePages = 10,
 }: PaginationProps): React.ReactElement {
-  const totalPages = Math.ceil(totalElements / totalElementsPerPage);
+  const totalPages = Math.ceil(totalElements / displayedElementsPerPage);
 
   const makeDisplayedPagesArray = (displayedPagesStart: number) => {
     return [...Array(totalDisplayablePages).keys()]
@@ -38,9 +38,9 @@ export function Pagination({
         return;
       }
       setPageState(Number(page));
-      handleSearchParamsChange(pageKey, page);
+      handleSearchParamsChange(searchParamPageKey, page);
     },
-    [handleSearchParamsChange, pageKey, setPageState]
+    [handleSearchParamsChange, searchParamPageKey, setPageState]
   );
 
   const hasPreviousPage = displayedPagesStart !== 1;

--- a/app/src/components/action_object_search/Pagination.tsx
+++ b/app/src/components/action_object_search/Pagination.tsx
@@ -2,7 +2,6 @@ import { Button, ButtonGroup, HStack } from '@chakra-ui/react';
 import {
   type SearchParamKey,
   SEARCH_RESULT_PAGE_KEY,
-  TOTAL_VIDEOS_PER_PAGE,
 } from 'constants/action_object_search/constants';
 import React, { useCallback, useState } from 'react';
 
@@ -10,17 +9,19 @@ type PaginationProps = {
   searchResultPage: number;
   setSearchResultPage: (searchResultPage: number) => void;
   handleSearchParamsChange: (key: SearchParamKey, value: string) => void;
-  totalVideos: number;
+  totalElements: number;
+  totalElementsPerPage: number;
   totalDisplayablePages?: number;
 };
 export function Pagination({
   searchResultPage,
   setSearchResultPage,
   handleSearchParamsChange,
-  totalVideos,
+  totalElements,
+  totalElementsPerPage,
   totalDisplayablePages = 10,
 }: PaginationProps): React.ReactElement {
-  const totalPages = Math.ceil(totalVideos / TOTAL_VIDEOS_PER_PAGE);
+  const totalPages = Math.ceil(totalElements / totalElementsPerPage);
 
   const makeDisplayedPagesArray = (displayedPagesStart: number) => {
     return [...Array(totalDisplayablePages).keys()]

--- a/app/src/components/action_object_search/VideoGrid.tsx
+++ b/app/src/components/action_object_search/VideoGrid.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import {
   IRI_KEY,
-  IS_VIDEO_SEGMENT_KEY,
   MAIN_OBJECT_KEY,
   TARGET_OBJECT_KEY,
 } from 'constants/action_object_search/constants';
@@ -54,7 +53,6 @@ export function VideoGrid({
               to={`/action-object-search/2d-bbox-image?${new URLSearchParams({
                 [MAIN_OBJECT_KEY]: mainObject,
                 [TARGET_OBJECT_KEY]: targetObject,
-                [IS_VIDEO_SEGMENT_KEY]: String(hasVideoSegment),
                 [IRI_KEY]: hasVideoSegment
                   ? video.videoSegment.value
                   : video.camera.value,

--- a/app/src/components/action_object_search/VideoGrid.tsx
+++ b/app/src/components/action_object_search/VideoGrid.tsx
@@ -15,8 +15,14 @@ function getVideoDurationAsMediaFragment(video: VideoSegmentQueryType) {
 
 type VideoGridProps = {
   videos: VideoQueryType[] | VideoSegmentQueryType[];
+  mainObject: string;
+  targetObject: string;
 };
-export function VideoGrid({ videos }: VideoGridProps): React.ReactElement {
+export function VideoGrid({
+  videos,
+  mainObject,
+  targetObject,
+}: VideoGridProps): React.ReactElement {
   return (
     <Grid templateColumns="repeat(3, 1fr)" gap={4}>
       {videos.map((video) => {
@@ -37,7 +43,17 @@ export function VideoGrid({ videos }: VideoGridProps): React.ReactElement {
               width="100%"
               height="auto"
             />
-            <Link as={ReactRouterLink} to={``} state={{}}>
+            <Link
+              as={ReactRouterLink}
+              to={`/action-object-search/2d-bbox-image?${new URLSearchParams({
+                mainObject,
+                targetObject,
+                isVideoSegment: String(hasVideoSegment),
+                iri: hasVideoSegment
+                  ? video.videoSegment.value
+                  : video.camera.value,
+              }).toString()}`}
+            >
               {hasVideoSegment
                 ? video.videoSegment.value.split('/').pop()
                 : video.camera.value.split('/').pop()}

--- a/app/src/components/action_object_search/VideoGrid.tsx
+++ b/app/src/components/action_object_search/VideoGrid.tsx
@@ -5,6 +5,12 @@ import {
 } from 'utils/action_object_search/sparql';
 import React from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
+import {
+  IRI_KEY,
+  IS_VIDEO_SEGMENT_KEY,
+  MAIN_OBJECT_KEY,
+  TARGET_OBJECT_KEY,
+} from 'constants/action_object_search/constants';
 
 function getVideoDurationAsMediaFragment(video: VideoSegmentQueryType) {
   const frameRate = Number(video.frameRate.value);
@@ -46,10 +52,10 @@ export function VideoGrid({
             <Link
               as={ReactRouterLink}
               to={`/action-object-search/2d-bbox-image?${new URLSearchParams({
-                mainObject,
-                targetObject,
-                isVideoSegment: String(hasVideoSegment),
-                iri: hasVideoSegment
+                [MAIN_OBJECT_KEY]: mainObject,
+                [TARGET_OBJECT_KEY]: targetObject,
+                [IS_VIDEO_SEGMENT_KEY]: String(hasVideoSegment),
+                [IRI_KEY]: hasVideoSegment
                   ? video.videoSegment.value
                   : video.camera.value,
               }).toString()}`}

--- a/app/src/constants/action_object_search/constants.ts
+++ b/app/src/constants/action_object_search/constants.ts
@@ -7,7 +7,10 @@ export type SearchParamKey =
   | 'searchResultPage'
   | 'scene'
   | 'camera'
-  | SearchParamObjectKey;
+  | SearchParamObjectKey
+  | 'isVideoSegment'
+  | 'iri'
+  | 'imageViewerPage';
 export const ACTION_KEY: SearchParamKey = 'action';
 export const MAIN_OBJECT_KEY: SearchParamKey = 'mainObject';
 export const TARGET_OBJECT_KEY: SearchParamKey = 'targetObject';
@@ -15,3 +18,6 @@ export const VIDEO_DURATION_KEY: SearchParamKey = 'videoDuration';
 export const SEARCH_RESULT_PAGE_KEY: SearchParamKey = 'searchResultPage';
 export const SCENE_KEY: SearchParamKey = 'scene';
 export const CAMERA_KEY: SearchParamKey = 'camera';
+export const IS_VIDEO_SEGMENT_KEY: SearchParamKey = 'isVideoSegment';
+export const IRI_KEY: SearchParamKey = 'iri';
+export const IMAGE_VIEWER_PAGE_KEY: SearchParamKey = 'imageViewerPage';

--- a/app/src/constants/action_object_search/constants.ts
+++ b/app/src/constants/action_object_search/constants.ts
@@ -1,4 +1,5 @@
 export const TOTAL_VIDEOS_PER_PAGE = 9;
+export const TOTAL_IMAGES_PER_PAGE = 1;
 
 export type SearchParamObjectKey = 'mainObject' | 'targetObject';
 export type SearchParamKey =

--- a/app/src/constants/action_object_search/constants.ts
+++ b/app/src/constants/action_object_search/constants.ts
@@ -19,6 +19,5 @@ export const VIDEO_DURATION_KEY: SearchParamKey = 'videoDuration';
 export const SEARCH_RESULT_PAGE_KEY: SearchParamKey = 'searchResultPage';
 export const SCENE_KEY: SearchParamKey = 'scene';
 export const CAMERA_KEY: SearchParamKey = 'camera';
-export const IS_VIDEO_SEGMENT_KEY: SearchParamKey = 'isVideoSegment';
 export const IRI_KEY: SearchParamKey = 'iri';
 export const IMAGE_VIEWER_PAGE_KEY: SearchParamKey = 'imageViewerPage';

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -1,4 +1,4 @@
-import { Box, ChakraProvider } from '@chakra-ui/react';
+import { Box, Center, ChakraProvider } from '@chakra-ui/react';
 import { Pagination } from 'components/action_object_search/Pagination';
 import {
   IMAGE_VIEWER_PAGE_KEY,
@@ -94,21 +94,25 @@ function BoundingBoxImageViewer(): React.ReactElement {
 
   return (
     <ChakraProvider>
-      <Box>
-        <canvas
-          width={`${resolutionX}px`}
-          height={`${resolutionY}px`}
-          id="image"
-        />
-        <Pagination
-          pageState={imageViewerPage}
-          setPageState={setImageViewerPage}
-          pageKey={IMAGE_VIEWER_PAGE_KEY}
-          handleSearchParamsChange={handleSearchParamsChange}
-          totalElements={frameCount}
-          totalElementsPerPage={1}
-        />
-      </Box>
+      <Center>
+        <Box>
+          <Center>
+            <canvas
+              width={`${resolutionX}px`}
+              height={`${resolutionY}px`}
+              id="image"
+            />
+          </Center>
+          <Pagination
+            pageState={imageViewerPage}
+            setPageState={setImageViewerPage}
+            pageKey={IMAGE_VIEWER_PAGE_KEY}
+            handleSearchParamsChange={handleSearchParamsChange}
+            totalElements={frameCount}
+            totalElementsPerPage={1}
+          />
+        </Box>
+      </Center>
     </ChakraProvider>
   );
 }

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -107,10 +107,10 @@ function BoundingBoxImageViewer(): React.ReactElement {
           <Pagination
             pageState={imageViewerPage}
             setPageState={setImageViewerPage}
-            pageKey={IMAGE_VIEWER_PAGE_KEY}
+            searchParamPageKey={IMAGE_VIEWER_PAGE_KEY}
             handleSearchParamsChange={handleSearchParamsChange}
             totalElements={frameCount}
-            totalElementsPerPage={TOTAL_IMAGES_PER_PAGE}
+            displayedElementsPerPage={TOTAL_IMAGES_PER_PAGE}
           />
         </Box>
       </Center>

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -32,8 +32,10 @@ function BoundingBoxImageViewer(): React.ReactElement {
   );
   const [canvasContext, setCanvasContext] =
     useState<CanvasRenderingContext2D | null>(null);
-  const [resolutionX, setResolutionX] = useState(0);
-  const [resolutionY, setResolutionY] = useState(0);
+  const [resolution, setResolution] = useState<{
+    width: number;
+    height: number;
+  }>({ width: 0, height: 0 });
 
   const isAnyRequiredParamEmpty = mainObject === '' || iri === '';
   const frameCount = frames.length;
@@ -67,9 +69,11 @@ function BoundingBoxImageViewer(): React.ReactElement {
       const splitImages = await fetchImage(
         frames[imageViewerPage - 1].frame.value
       );
-      const [resX, resY] = splitImages[0].resolution.value.split('x'); // "1920x1080" -> ["1920", "1080"]
-      setResolutionX(Number(resX));
-      setResolutionY(Number(resY));
+
+      const [width, height] = splitImages[0].resolution.value
+        .split('x')
+        .map((v) => Number(v)); // "1920x1080" -> [1920, 1080]
+      setResolution({ width, height });
 
       splitImages.forEach((image, index) => {
         const img = new Image();
@@ -99,8 +103,8 @@ function BoundingBoxImageViewer(): React.ReactElement {
         <Box>
           <Center>
             <canvas
-              width={`${resolutionX}px`}
-              height={`${resolutionY}px`}
+              width={`${resolution.width}px`}
+              height={`${resolution.height}px`}
               id="image"
             />
           </Center>

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -1,4 +1,94 @@
+import { Box, ChakraProvider } from '@chakra-ui/react';
+import { Pagination } from 'components/action_object_search/Pagination';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  type FrameQueryType,
+  ImageQueryType,
+  fetchFrameByCamera,
+  fetchFrameByVideoSegment,
+  fetchImage,
+} from 'utils/action_object_search/2d-bbox-image/sparql';
+
 function BoundingBoxImageViewer(): React.ReactElement {
-  return <></>;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const mainObject = searchParams.get('mainObject') || '';
+  const targetObject = searchParams.get('targetObject') || '';
+  const isVideoSegment = searchParams.get('isVideoSegment') === 'true';
+  const iri = searchParams.get('iri') || '';
+
+  const [frames, setFrames] = useState<FrameQueryType[]>([]);
+  const [imagePage, setImagePage] = useState(1);
+  const [canvasContext, setCanvasContext] =
+    useState<CanvasRenderingContext2D | null>(null);
+  const [resolutionX, setResolutionX] = useState(0);
+  const [resolutionY, setResolutionY] = useState(0);
+
+  const anyRequiredParamIsEmpty = mainObject === '' || iri === '';
+  const frameCount = frames.length;
+
+  useEffect(() => {
+    const canvas = document.getElementById('resultImage') as HTMLCanvasElement;
+    const context = canvas.getContext('2d');
+    setCanvasContext(context);
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      if (anyRequiredParamIsEmpty) {
+        return;
+      }
+
+      if (isVideoSegment) {
+        setFrames(
+          await fetchFrameByVideoSegment(iri, mainObject, targetObject)
+        );
+      } else {
+        setFrames(await fetchFrameByCamera(iri, mainObject, targetObject));
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      if (frames.length === 0) {
+        return;
+      }
+
+      const splitImages = await fetchImage(frames[imagePage - 1].frame.value);
+      setResolutionX(Number(splitImages[0].resolution.value.split('x')[0]));
+      setResolutionY(Number(splitImages[0].resolution.value.split('x')[1]));
+
+      splitImages.forEach((image, index) => {
+        const img = new Image();
+        img.src = `data:image/jpeg;base64,${image.base64SplitImage.value}`;
+        img.onload = () => {
+          const x = (index % Number(image.splitWidth.value)) * img.width;
+          const y =
+            Math.floor(index / Number(image.splitHeight.value)) * img.height;
+          canvasContext?.drawImage(img, x, y);
+        };
+      });
+    })();
+  }, [frames, imagePage]);
+
+  return (
+    <ChakraProvider>
+      <Box>
+        <canvas
+          width={`${resolutionX}px`}
+          height={`${resolutionY}px`}
+          id="resultImage"
+        />
+        <Pagination
+          searchResultPage={imagePage}
+          setSearchResultPage={setImagePage}
+          handleSearchParamsChange={() => {}}
+          totalVideos={frameCount}
+          totalDisplayablePages={10}
+        />
+      </Box>
+    </ChakraProvider>
+  );
 }
 export default BoundingBoxImageViewer;

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -9,7 +9,7 @@ import {
   TARGET_OBJECT_KEY,
   TOTAL_IMAGES_PER_PAGE,
 } from 'constants/action_object_search/constants';
-import { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   type FrameQueryType,

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -84,8 +84,8 @@ function BoundingBoxImageViewer(): React.ReactElement {
           searchResultPage={imagePage}
           setSearchResultPage={setImagePage}
           handleSearchParamsChange={() => {}}
-          totalVideos={frameCount}
-          totalDisplayablePages={10}
+          totalElements={frameCount}
+          totalElementsPerPage={1}
         />
       </Box>
     </ChakraProvider>

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -7,6 +7,7 @@ import {
   MAIN_OBJECT_KEY,
   type SearchParamKey,
   TARGET_OBJECT_KEY,
+  TOTAL_IMAGES_PER_PAGE,
 } from 'constants/action_object_search/constants';
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -109,7 +110,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
             pageKey={IMAGE_VIEWER_PAGE_KEY}
             handleSearchParamsChange={handleSearchParamsChange}
             totalElements={frameCount}
-            totalElementsPerPage={1}
+            totalElementsPerPage={TOTAL_IMAGES_PER_PAGE}
           />
         </Box>
       </Center>

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -1,0 +1,4 @@
+function BoundingBoxImageViewer(): React.ReactElement {
+  return <></>;
+}
+export default BoundingBoxImageViewer;

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -3,7 +3,6 @@ import { Pagination } from 'components/action_object_search/Pagination';
 import {
   IMAGE_VIEWER_PAGE_KEY,
   IRI_KEY,
-  IS_VIDEO_SEGMENT_KEY,
   MAIN_OBJECT_KEY,
   type SearchParamKey,
   TARGET_OBJECT_KEY,
@@ -23,7 +22,6 @@ function BoundingBoxImageViewer(): React.ReactElement {
 
   const mainObject = searchParams.get(MAIN_OBJECT_KEY) || '';
   const targetObject = searchParams.get(TARGET_OBJECT_KEY) || '';
-  const isVideoSegment = searchParams.get(IS_VIDEO_SEGMENT_KEY) === 'true';
   const iri = searchParams.get(IRI_KEY) || '';
 
   const [frames, setFrames] = useState<FrameQueryType[]>([]);
@@ -38,6 +36,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
   }>({ width: 0, height: 0 });
 
   const isAnyRequiredParamEmpty = mainObject === '' || iri === '';
+  const isVideoSegment = iri.includes('video_segment');
   const frameCount = frames.length;
 
   useEffect(() => {

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -34,7 +34,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
   const [resolutionX, setResolutionX] = useState(0);
   const [resolutionY, setResolutionY] = useState(0);
 
-  const anyRequiredParamIsEmpty = mainObject === '' || iri === '';
+  const isAnyRequiredParamEmpty = mainObject === '' || iri === '';
   const frameCount = frames.length;
 
   useEffect(() => {
@@ -43,7 +43,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
     setCanvasContext(context);
 
     (async () => {
-      if (anyRequiredParamIsEmpty) {
+      if (isAnyRequiredParamEmpty) {
         return;
       }
 
@@ -66,7 +66,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
       const splitImages = await fetchImage(
         frames[imageViewerPage - 1].frame.value
       );
-      const [resX, resY] = splitImages[0].resolution.value.split('x');
+      const [resX, resY] = splitImages[0].resolution.value.split('x'); // "1920x1080" -> ["1920", "1080"]
       setResolutionX(Number(resX));
       setResolutionY(Number(resY));
 

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   type FrameQueryType,
-  ImageQueryType,
   fetchFrameByCamera,
   fetchFrameByVideoSegment,
   fetchImage,
@@ -12,6 +11,7 @@ import {
 
 function BoundingBoxImageViewer(): React.ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+
   const mainObject = searchParams.get('mainObject') || '';
   const targetObject = searchParams.get('targetObject') || '';
   const isVideoSegment = searchParams.get('isVideoSegment') === 'true';
@@ -28,12 +28,10 @@ function BoundingBoxImageViewer(): React.ReactElement {
   const frameCount = frames.length;
 
   useEffect(() => {
-    const canvas = document.getElementById('resultImage') as HTMLCanvasElement;
+    const canvas = document.getElementById('image') as HTMLCanvasElement;
     const context = canvas.getContext('2d');
     setCanvasContext(context);
-  }, []);
 
-  useEffect(() => {
     (async () => {
       if (anyRequiredParamIsEmpty) {
         return;
@@ -51,13 +49,14 @@ function BoundingBoxImageViewer(): React.ReactElement {
 
   useEffect(() => {
     (async () => {
-      if (frames.length === 0) {
+      if (frameCount === 0) {
         return;
       }
 
       const splitImages = await fetchImage(frames[imagePage - 1].frame.value);
-      setResolutionX(Number(splitImages[0].resolution.value.split('x')[0]));
-      setResolutionY(Number(splitImages[0].resolution.value.split('x')[1]));
+      const [resX, resY] = splitImages[0].resolution.value.split('x');
+      setResolutionX(Number(resX));
+      setResolutionY(Number(resY));
 
       splitImages.forEach((image, index) => {
         const img = new Image();
@@ -78,7 +77,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
         <canvas
           width={`${resolutionX}px`}
           height={`${resolutionY}px`}
-          id="resultImage"
+          id="image"
         />
         <Pagination
           searchResultPage={imagePage}

--- a/app/src/pages/action_object_search/index.tsx
+++ b/app/src/pages/action_object_search/index.tsx
@@ -259,9 +259,19 @@ function ActionObjectSearch(): React.ReactElement {
             </Tbody>
           </Table>
         </TableContainer>
-        {selectedVideoDuration === 'full' && <VideoGrid videos={videos} />}
+        {selectedVideoDuration === 'full' && (
+          <VideoGrid
+            videos={videos}
+            mainObject={mainObject}
+            targetObject={targetObject}
+          />
+        )}
         {selectedVideoDuration === 'segment' && (
-          <VideoGrid videos={videoSegments} />
+          <VideoGrid
+            videos={videoSegments}
+            mainObject={mainObject}
+            targetObject={targetObject}
+          />
         )}
         <Pagination
           searchResultPage={searchResultPage}

--- a/app/src/pages/action_object_search/index.tsx
+++ b/app/src/pages/action_object_search/index.tsx
@@ -276,10 +276,10 @@ function ActionObjectSearch(): React.ReactElement {
         <Pagination
           pageState={searchResultPage}
           setPageState={setSearchResultPage}
-          pageKey={SEARCH_RESULT_PAGE_KEY}
+          searchParamPageKey={SEARCH_RESULT_PAGE_KEY}
           handleSearchParamsChange={handleSearchParamsChange}
           totalElements={videoCount}
-          totalElementsPerPage={TOTAL_VIDEOS_PER_PAGE}
+          displayedElementsPerPage={TOTAL_VIDEOS_PER_PAGE}
         />
       </Flex>
     </ChakraProvider>

--- a/app/src/pages/action_object_search/index.tsx
+++ b/app/src/pages/action_object_search/index.tsx
@@ -274,8 +274,9 @@ function ActionObjectSearch(): React.ReactElement {
           />
         )}
         <Pagination
-          searchResultPage={searchResultPage}
-          setSearchResultPage={setSearchResultPage}
+          pageState={searchResultPage}
+          setPageState={setSearchResultPage}
+          pageKey={SEARCH_RESULT_PAGE_KEY}
           handleSearchParamsChange={handleSearchParamsChange}
           totalElements={videoCount}
           totalElementsPerPage={TOTAL_VIDEOS_PER_PAGE}

--- a/app/src/pages/action_object_search/index.tsx
+++ b/app/src/pages/action_object_search/index.tsx
@@ -277,7 +277,8 @@ function ActionObjectSearch(): React.ReactElement {
           searchResultPage={searchResultPage}
           setSearchResultPage={setSearchResultPage}
           handleSearchParamsChange={handleSearchParamsChange}
-          totalVideos={videoCount}
+          totalElements={videoCount}
+          totalElementsPerPage={TOTAL_VIDEOS_PER_PAGE}
         />
       </Flex>
     </ChakraProvider>

--- a/app/src/router/router.tsx
+++ b/app/src/router/router.tsx
@@ -2,6 +2,7 @@ import ActionObjectSearch from 'pages/action_object_search';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from 'pages';
 import React from 'react';
+import BoundingBoxImageViewer from 'pages/action_object_search/2d-bbox-image';
 
 const Router = (): React.ReactElement => {
   const router = createBrowserRouter([
@@ -12,6 +13,10 @@ const Router = (): React.ReactElement => {
     {
       path: '/action-object-search',
       element: <ActionObjectSearch />,
+    },
+    {
+      path: '/action-object-search/2d-bbox-image',
+      element: <BoundingBoxImageViewer />,
     },
   ]);
 

--- a/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
+++ b/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
@@ -1,0 +1,117 @@
+import { NamedNode } from 'rdf-js';
+import { makeClient } from 'utils/common/sparql';
+
+export type FrameQueryType = {
+  frame: NamedNode;
+};
+export const fetchFrameByCamera: (
+  cameraIri: string,
+  mainObject: string,
+  targetObject: string
+) => Promise<FrameQueryType[]> = async (
+  cameraIri,
+  mainObject,
+  targetObject
+) => {
+  const query = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT DISTINCT ?frame WHERE { 
+      BIND (<${cameraIri}> AS ?camera) .
+      BIND ("${mainObject}" AS ?mainObjectName) .
+      BIND ("${targetObject}" AS ?targetObjectName) .
+      
+      ?scene vh2kg:hasVideo ?camera .
+      ?scene vh2kg:hasEvent ?event .
+      ?event vh2kg:mainObject ?mainObject .
+      ${targetObject !== '' ? '?event vh2kg:targetObject ?targetObject .' : ''}
+      
+      ?camera mssn:hasMediaSegment ?videoSegment .
+      ?videoSegment mssn:hasMediaDescriptor ?frame .
+      ?frame mssn:hasMediaDescriptor ?object ;
+      {{?object vh2kg:is2DbboxOf ?mainObject} UNION {?object vh2kg:is2DbboxOf ?targetObject}} .
+      
+      ?mainObject rdfs:label ?mainObjectLabel .
+      ?targetObject rdfs:label ?targetObjectLabel .
+      FILTER regex(?mainObjectLabel, ?mainObjectName, "i") .
+      FILTER regex(?targetObjectLabel, ?targetObjectName, "i") .
+    } ORDER BY asc(?frame)
+  `;
+  const result = (await makeClient().query.select(query)) as FrameQueryType[];
+  return result;
+};
+
+export const fetchFrameByVideoSegment: (
+  videoSegmentIri: string,
+  mainObject: string,
+  targetObject: string
+) => Promise<FrameQueryType[]> = async (
+  videoSegmentIri,
+  mainObject,
+  targetObject
+) => {
+  const query = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT DISTINCT ?frame WHERE { 
+      BIND (<${videoSegmentIri}> AS ?videoSegment) .
+      BIND ("${mainObject}" AS ?mainObjectName) .
+      BIND ("${targetObject}" AS ?targetObjectName) .
+      
+      ?scene vh2kg:hasVideo ?camera .
+      ?scene vh2kg:hasEvent ?event .
+      ?event vh2kg:mainObject ?mainObject .
+      ${targetObject !== '' ? '?event vh2kg:targetObject ?targetObject .' : ''}
+      
+      ?camera mssn:hasMediaSegment ?videoSegment .
+      ?videoSegment mssn:hasMediaDescriptor ?frame .
+      ?frame mssn:hasMediaDescriptor ?object ;
+      {{?object vh2kg:is2DbboxOf ?mainObject} UNION {?object vh2kg:is2DbboxOf ?targetObject}} .
+      
+      ?mainObject rdfs:label ?mainObjectLabel .
+      ?targetObject rdfs:label ?targetObjectLabel .
+      FILTER regex(?mainObjectLabel, ?mainObjectName, "i") .
+      FILTER regex(?targetObjectLabel, ?targetObjectName, "i") .
+    } ORDER BY asc(?frame)
+  `;
+  const result = (await makeClient().query.select(query)) as FrameQueryType[];
+  return result;
+};
+
+export type ImageQueryType = {
+  base64SplitImage: NamedNode;
+  splitImageId: NamedNode;
+  resolution: NamedNode;
+  splitWidth: NamedNode;
+  splitHeight: NamedNode;
+};
+export const fetchImage: (
+  frameIri: string
+) => Promise<ImageQueryType[]> = async (frameIri) => {
+  const query = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT DISTINCT ?base64SplitImage ?splitImageId ?resolution ?splitWidth ?splitHeight WHERE { 
+        BIND (<${frameIri}> AS ?frame) .
+        ?videoSegment mssn:hasMediaDescriptor ?frame .
+        ?camera mssn:hasMediaSegment ?videoSegment ;
+                vh2kg:hasResolution ?resolution .
+        ?frame vh2kg:image ?splitImage ;
+               vh2kg:splitWidth ?splitWidth ;
+               vh2kg:splitHeight ?splitHeight .
+        ?splitImage vh2kg:splitImageID ?splitImageId ;
+                    rdf:value ?base64SplitImage .
+    } ORDER BY asc(?splitImageId)
+  `;
+  const result = (await makeClient().query.select(query)) as ImageQueryType[];
+  return result;
+};

--- a/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
+++ b/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
@@ -13,6 +13,7 @@ export const fetchFrameByCamera: (
   mainObject,
   targetObject
 ) => {
+  const isTargetObjectSpecified = targetObject !== '';
   const query = `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
@@ -22,22 +23,26 @@ export const fetchFrameByCamera: (
     SELECT DISTINCT ?frame WHERE { 
       BIND (<${cameraIri}> AS ?camera) .
       BIND ("${mainObject}" AS ?mainObjectName) .
-      BIND ("${targetObject}" AS ?targetObjectName) .
+      ${isTargetObjectSpecified ? `BIND ("${targetObject}" AS ?targetObjectName) .` : ''}
       
       ?scene vh2kg:hasVideo ?camera .
       ?scene vh2kg:hasEvent ?event .
       ?event vh2kg:mainObject ?mainObject .
-      ${targetObject !== '' ? '?event vh2kg:targetObject ?targetObject .' : ''}
+      ${isTargetObjectSpecified ? '?event vh2kg:targetObject ?targetObject .' : ''}
       
       ?camera mssn:hasMediaSegment ?videoSegment .
       ?videoSegment mssn:hasMediaDescriptor ?frame .
-      ?frame mssn:hasMediaDescriptor ?object ;
-      {{?object vh2kg:is2DbboxOf ?mainObject} UNION {?object vh2kg:is2DbboxOf ?targetObject}} .
+      ?frame mssn:hasMediaDescriptor ?object .
+      ${
+        isTargetObjectSpecified
+          ? `{{?object vh2kg:is2DbboxOf ?mainObject} UNION {?object vh2kg:is2DbboxOf ?targetObject}} .`
+          : `?object vh2kg:is2DbboxOf ?mainObject .`
+      }
       
       ?mainObject rdfs:label ?mainObjectLabel .
-      ?targetObject rdfs:label ?targetObjectLabel .
+      ${isTargetObjectSpecified ? `?targetObject rdfs:label ?targetObjectLabel .` : ''}
       FILTER regex(?mainObjectLabel, ?mainObjectName, "i") .
-      FILTER regex(?targetObjectLabel, ?targetObjectName, "i") .
+      ${isTargetObjectSpecified ? `FILTER regex(?targetObjectLabel, ?targetObjectName, "i") . ` : ''}
     } ORDER BY asc(?frame)
   `;
   const result = (await makeClient().query.select(query)) as FrameQueryType[];
@@ -53,6 +58,7 @@ export const fetchFrameByVideoSegment: (
   mainObject,
   targetObject
 ) => {
+  const isTargetObjectSpecified = targetObject !== '';
   const query = `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
@@ -62,22 +68,26 @@ export const fetchFrameByVideoSegment: (
     SELECT DISTINCT ?frame WHERE { 
       BIND (<${videoSegmentIri}> AS ?videoSegment) .
       BIND ("${mainObject}" AS ?mainObjectName) .
-      BIND ("${targetObject}" AS ?targetObjectName) .
+      ${isTargetObjectSpecified ? `BIND ("${targetObject}" AS ?targetObjectName) .` : ''}
       
       ?scene vh2kg:hasVideo ?camera .
       ?scene vh2kg:hasEvent ?event .
       ?event vh2kg:mainObject ?mainObject .
-      ${targetObject !== '' ? '?event vh2kg:targetObject ?targetObject .' : ''}
+      ${isTargetObjectSpecified ? '?event vh2kg:targetObject ?targetObject .' : ''}
       
       ?camera mssn:hasMediaSegment ?videoSegment .
       ?videoSegment mssn:hasMediaDescriptor ?frame .
-      ?frame mssn:hasMediaDescriptor ?object ;
-      {{?object vh2kg:is2DbboxOf ?mainObject} UNION {?object vh2kg:is2DbboxOf ?targetObject}} .
+      ?frame mssn:hasMediaDescriptor ?object .
+      ${
+        isTargetObjectSpecified
+          ? `{{?object vh2kg:is2DbboxOf ?mainObject} UNION {?object vh2kg:is2DbboxOf ?targetObject}} .`
+          : `?object vh2kg:is2DbboxOf ?mainObject .`
+      }
       
       ?mainObject rdfs:label ?mainObjectLabel .
-      ?targetObject rdfs:label ?targetObjectLabel .
+      ${isTargetObjectSpecified ? `?targetObject rdfs:label ?targetObjectLabel .` : ''}
       FILTER regex(?mainObjectLabel, ?mainObjectName, "i") .
-      FILTER regex(?targetObjectLabel, ?targetObjectName, "i") .
+      ${isTargetObjectSpecified ? `FILTER regex(?targetObjectLabel, ?targetObjectName, "i") .` : ''}
     } ORDER BY asc(?frame)
   `;
   const result = (await makeClient().query.select(query)) as FrameQueryType[];


### PR DESCRIPTION
## 変更の概要
- 画像を表示するページを作成しました
## なぜこの変更をするのか
- 指定されたオブジェクトのBounding Boxを画像で確認できるようにするためです。
## やったこと
- `app/src/pages/action_object_search/2d-bbox-image/index.tsx`に画像の表示ページを作成
- `app/src/router/router.tsx`にルーティングの設定
- `app/src/components/action_object_search/VideoGrid.tsx`に画像ページへのリンクを追加
- `app/src/utils/action_object_search/2d-bbox-image/sparql.ts`に画像取得のクエリを追加
## やらないこと
- 画像表示ページから動画ページへ戻るボタンの追加
入力していた検索条件を保存する処理等の実装により、こちらのPRの規模が大きくなるため別PRで作成します。

## できるようになること
- フレームごとに検索した動画を確認できるようになります
## できなくなること
## 動作確認方法
## その他
添付のスクリーンショットと録画も併せてご確認ください。

<img width="1840" alt="Screenshot 2024-11-26 at 11 53 17" src="https://github.com/user-attachments/assets/5ab74338-1a43-4c7f-aa50-201c365cb1ca">

https://github.com/user-attachments/assets/56ac2579-307a-4b1c-8f73-85fb41dea7a9


