### PR TITLE
画像表示ページから動画検索ページへ戻るボタンの追加

### DIFF
--- a/app/src/components/action_object_search/2d-bbox-image/BackToVideoSearchButton.tsx
+++ b/app/src/components/action_object_search/2d-bbox-image/BackToVideoSearchButton.tsx
@@ -1,26 +1,14 @@
 import { Button, Center } from '@chakra-ui/react';
-import {
-  IRI_KEY,
-  MAIN_OBJECT_KEY,
-  TARGET_OBJECT_KEY,
-} from 'constants/action_object_search/constants';
+import { VIDEO_SEARCH_SESSION_STORAGE_KEY } from 'constants/action_object_search/constants';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export function BackToVideoSearchButton(): React.ReactElement {
   const navigate = useNavigate();
   const handleClick = useCallback(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-
-    // 2d-bbox-pageを決定するパラメータの組み合わせごとに、
-    // 直近の遷移元の動画検索結果を表示するためのクエリパラメータをlocalStorageに保存している
-    const localStorageKey = new URLSearchParams({
-      [MAIN_OBJECT_KEY]: searchParams.get(MAIN_OBJECT_KEY) || '',
-      [TARGET_OBJECT_KEY]: searchParams.get(TARGET_OBJECT_KEY) || '',
-      [IRI_KEY]: searchParams.get(IRI_KEY) || '',
-    }).toString();
-
-    const videoSearchParams = localStorage.getItem(localStorageKey);
+    const videoSearchParams = sessionStorage.getItem(
+      VIDEO_SEARCH_SESSION_STORAGE_KEY
+    );
     if (videoSearchParams) {
       navigate('/action-object-search?' + videoSearchParams);
     } else {

--- a/app/src/components/action_object_search/2d-bbox-image/BackToVideoSearchButton.tsx
+++ b/app/src/components/action_object_search/2d-bbox-image/BackToVideoSearchButton.tsx
@@ -3,7 +3,7 @@ import { VIDEO_SEARCH_SESSION_STORAGE_KEY } from 'constants/action_object_search
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-export function ReturnVideoSearchButton(): React.ReactElement {
+export function BackToVideoSearchButton(): React.ReactElement {
   const navigate = useNavigate();
   const handleClick = useCallback(() => {
     const videoSearchParams = sessionStorage.getItem(
@@ -17,7 +17,7 @@ export function ReturnVideoSearchButton(): React.ReactElement {
   }, []);
   return (
     <Center>
-      <Button onClick={handleClick}>Return</Button>
+      <Button onClick={handleClick}>Back</Button>
     </Center>
   );
 }

--- a/app/src/components/action_object_search/2d-bbox-image/BackToVideoSearchButton.tsx
+++ b/app/src/components/action_object_search/2d-bbox-image/BackToVideoSearchButton.tsx
@@ -1,14 +1,26 @@
 import { Button, Center } from '@chakra-ui/react';
-import { VIDEO_SEARCH_SESSION_STORAGE_KEY } from 'constants/action_object_search/constants';
+import {
+  IRI_KEY,
+  MAIN_OBJECT_KEY,
+  TARGET_OBJECT_KEY,
+} from 'constants/action_object_search/constants';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export function BackToVideoSearchButton(): React.ReactElement {
   const navigate = useNavigate();
   const handleClick = useCallback(() => {
-    const videoSearchParams = sessionStorage.getItem(
-      VIDEO_SEARCH_SESSION_STORAGE_KEY
-    );
+    const searchParams = new URLSearchParams(window.location.search);
+
+    // 2d-bbox-pageを決定するパラメータの組み合わせごとに、
+    // 直近の遷移元の動画検索結果を表示するためのクエリパラメータをlocalStorageに保存している
+    const localStorageKey = new URLSearchParams({
+      [MAIN_OBJECT_KEY]: searchParams.get(MAIN_OBJECT_KEY) || '',
+      [TARGET_OBJECT_KEY]: searchParams.get(TARGET_OBJECT_KEY) || '',
+      [IRI_KEY]: searchParams.get(IRI_KEY) || '',
+    }).toString();
+
+    const videoSearchParams = localStorage.getItem(localStorageKey);
     if (videoSearchParams) {
       navigate('/action-object-search?' + videoSearchParams);
     } else {

--- a/app/src/components/action_object_search/2d-bbox-image/ReturnVideoSearchButton.tsx
+++ b/app/src/components/action_object_search/2d-bbox-image/ReturnVideoSearchButton.tsx
@@ -1,0 +1,23 @@
+import { Button, Center } from '@chakra-ui/react';
+import { VIDEO_SEARCH_SESSION_STORAGE_KEY } from 'constants/action_object_search/constants';
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export function ReturnVideoSearchButton(): React.ReactElement {
+  const navigate = useNavigate();
+  const handleClick = useCallback(() => {
+    const videoSearchParams = sessionStorage.getItem(
+      VIDEO_SEARCH_SESSION_STORAGE_KEY
+    );
+    if (videoSearchParams) {
+      navigate('/action-object-search?' + videoSearchParams);
+    } else {
+      navigate('/action-object-search');
+    }
+  }, []);
+  return (
+    <Center>
+      <Button onClick={handleClick}>Return</Button>
+    </Center>
+  );
+}

--- a/app/src/components/action_object_search/ImagePageLink.tsx
+++ b/app/src/components/action_object_search/ImagePageLink.tsx
@@ -1,0 +1,45 @@
+import { Link } from '@chakra-ui/react';
+import {
+  IRI_KEY,
+  IS_VIDEO_SEGMENT_KEY,
+  MAIN_OBJECT_KEY,
+  TARGET_OBJECT_KEY,
+} from 'constants/action_object_search/constants';
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type ImagePageLinkProps = {
+  linkText: string;
+  mainObject: string;
+  targetObject: string;
+  isVideoSegment: boolean;
+  iri: string;
+};
+export function ImagePageLink({
+  linkText,
+  mainObject,
+  targetObject,
+  isVideoSegment,
+  iri,
+}: ImagePageLinkProps): React.ReactElement {
+  const navigate = useNavigate();
+
+  const handleClick = useCallback(() => {
+    const videoSearchParams = new URLSearchParams(window.location.search);
+    const sessionStorageKey = 'searchParams';
+    sessionStorage.removeItem(sessionStorageKey);
+    sessionStorage.setItem(sessionStorageKey, videoSearchParams.toString());
+
+    const imageSearchParams = new URLSearchParams({
+      [MAIN_OBJECT_KEY]: mainObject,
+      [TARGET_OBJECT_KEY]: targetObject,
+      [IS_VIDEO_SEGMENT_KEY]: isVideoSegment.toString(),
+      [IRI_KEY]: iri,
+    });
+    const path =
+      '/action-object-search/2d-bbox-image?' + imageSearchParams.toString();
+    navigate(path);
+  }, []);
+
+  return <Link onClick={handleClick}>{linkText}</Link>;
+}

--- a/app/src/components/action_object_search/ImagePageLink.tsx
+++ b/app/src/components/action_object_search/ImagePageLink.tsx
@@ -3,6 +3,7 @@ import {
   IRI_KEY,
   MAIN_OBJECT_KEY,
   TARGET_OBJECT_KEY,
+  VIDEO_SEARCH_SESSION_STORAGE_KEY,
 } from 'constants/action_object_search/constants';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -22,19 +23,20 @@ export function ImagePageLink({
   const navigate = useNavigate();
 
   const handleClick = useCallback(() => {
+    const videoSearchParams = new URLSearchParams(window.location.search);
+    sessionStorage.removeItem(VIDEO_SEARCH_SESSION_STORAGE_KEY);
+    sessionStorage.setItem(
+      VIDEO_SEARCH_SESSION_STORAGE_KEY,
+      videoSearchParams.toString()
+    );
+
     const imageSearchParams = new URLSearchParams({
       [MAIN_OBJECT_KEY]: mainObject,
       [TARGET_OBJECT_KEY]: targetObject,
       [IRI_KEY]: iri,
     });
-
-    const imageSearchParamsString = imageSearchParams.toString();
     const path =
-      '/action-object-search/2d-bbox-image?' + imageSearchParamsString;
-
-    const videoSearchParams = new URLSearchParams(window.location.search);
-    localStorage.removeItem(imageSearchParamsString);
-    localStorage.setItem(imageSearchParamsString, videoSearchParams.toString());
+      '/action-object-search/2d-bbox-image?' + imageSearchParams.toString();
     navigate(path);
   }, []);
 

--- a/app/src/components/action_object_search/ImagePageLink.tsx
+++ b/app/src/components/action_object_search/ImagePageLink.tsx
@@ -3,7 +3,6 @@ import {
   IRI_KEY,
   MAIN_OBJECT_KEY,
   TARGET_OBJECT_KEY,
-  VIDEO_SEARCH_SESSION_STORAGE_KEY,
 } from 'constants/action_object_search/constants';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -23,20 +22,19 @@ export function ImagePageLink({
   const navigate = useNavigate();
 
   const handleClick = useCallback(() => {
-    const videoSearchParams = new URLSearchParams(window.location.search);
-    sessionStorage.removeItem(VIDEO_SEARCH_SESSION_STORAGE_KEY);
-    sessionStorage.setItem(
-      VIDEO_SEARCH_SESSION_STORAGE_KEY,
-      videoSearchParams.toString()
-    );
-
     const imageSearchParams = new URLSearchParams({
       [MAIN_OBJECT_KEY]: mainObject,
       [TARGET_OBJECT_KEY]: targetObject,
       [IRI_KEY]: iri,
     });
+
+    const imageSearchParamsString = imageSearchParams.toString();
     const path =
-      '/action-object-search/2d-bbox-image?' + imageSearchParams.toString();
+      '/action-object-search/2d-bbox-image?' + imageSearchParamsString;
+
+    const videoSearchParams = new URLSearchParams(window.location.search);
+    localStorage.removeItem(imageSearchParamsString);
+    localStorage.setItem(imageSearchParamsString, videoSearchParams.toString());
     navigate(path);
   }, []);
 

--- a/app/src/components/action_object_search/ImagePageLink.tsx
+++ b/app/src/components/action_object_search/ImagePageLink.tsx
@@ -1,7 +1,6 @@
 import { Link } from '@chakra-ui/react';
 import {
   IRI_KEY,
-  IS_VIDEO_SEGMENT_KEY,
   MAIN_OBJECT_KEY,
   TARGET_OBJECT_KEY,
 } from 'constants/action_object_search/constants';
@@ -12,14 +11,12 @@ type ImagePageLinkProps = {
   linkText: string;
   mainObject: string;
   targetObject: string;
-  isVideoSegment: boolean;
   iri: string;
 };
 export function ImagePageLink({
   linkText,
   mainObject,
   targetObject,
-  isVideoSegment,
   iri,
 }: ImagePageLinkProps): React.ReactElement {
   const navigate = useNavigate();
@@ -33,7 +30,6 @@ export function ImagePageLink({
     const imageSearchParams = new URLSearchParams({
       [MAIN_OBJECT_KEY]: mainObject,
       [TARGET_OBJECT_KEY]: targetObject,
-      [IS_VIDEO_SEGMENT_KEY]: isVideoSegment.toString(),
       [IRI_KEY]: iri,
     });
     const path =

--- a/app/src/components/action_object_search/ImagePageLink.tsx
+++ b/app/src/components/action_object_search/ImagePageLink.tsx
@@ -3,6 +3,7 @@ import {
   IRI_KEY,
   MAIN_OBJECT_KEY,
   TARGET_OBJECT_KEY,
+  VIDEO_SEARCH_SESSION_STORAGE_KEY,
 } from 'constants/action_object_search/constants';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -23,9 +24,11 @@ export function ImagePageLink({
 
   const handleClick = useCallback(() => {
     const videoSearchParams = new URLSearchParams(window.location.search);
-    const sessionStorageKey = 'searchParams';
-    sessionStorage.removeItem(sessionStorageKey);
-    sessionStorage.setItem(sessionStorageKey, videoSearchParams.toString());
+    sessionStorage.removeItem(VIDEO_SEARCH_SESSION_STORAGE_KEY);
+    sessionStorage.setItem(
+      VIDEO_SEARCH_SESSION_STORAGE_KEY,
+      videoSearchParams.toString()
+    );
 
     const imageSearchParams = new URLSearchParams({
       [MAIN_OBJECT_KEY]: mainObject,

--- a/app/src/components/action_object_search/ImagePageLink.tsx
+++ b/app/src/components/action_object_search/ImagePageLink.tsx
@@ -1,12 +1,11 @@
 import { Link } from '@chakra-ui/react';
+import { Link as ReactRouterLink } from 'react-router-dom';
 import {
   IRI_KEY,
   MAIN_OBJECT_KEY,
   TARGET_OBJECT_KEY,
-  VIDEO_SEARCH_SESSION_STORAGE_KEY,
 } from 'constants/action_object_search/constants';
-import React, { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
 
 type ImagePageLinkProps = {
   linkText: string;
@@ -20,25 +19,16 @@ export function ImagePageLink({
   targetObject,
   iri,
 }: ImagePageLinkProps): React.ReactElement {
-  const navigate = useNavigate();
-
-  const handleClick = useCallback(() => {
-    const videoSearchParams = new URLSearchParams(window.location.search);
-    sessionStorage.removeItem(VIDEO_SEARCH_SESSION_STORAGE_KEY);
-    sessionStorage.setItem(
-      VIDEO_SEARCH_SESSION_STORAGE_KEY,
-      videoSearchParams.toString()
-    );
-
-    const imageSearchParams = new URLSearchParams({
-      [MAIN_OBJECT_KEY]: mainObject,
-      [TARGET_OBJECT_KEY]: targetObject,
-      [IRI_KEY]: iri,
-    });
-    const path =
-      '/action-object-search/2d-bbox-image?' + imageSearchParams.toString();
-    navigate(path);
-  }, []);
-
-  return <Link onClick={handleClick}>{linkText}</Link>;
+  const imageSearchParams = new URLSearchParams({
+    [MAIN_OBJECT_KEY]: mainObject,
+    [TARGET_OBJECT_KEY]: targetObject,
+    [IRI_KEY]: iri,
+  });
+  const path =
+    '/action-object-search/2d-bbox-image?' + imageSearchParams.toString();
+  return (
+    <Link as={ReactRouterLink} to={path}>
+      {linkText}
+    </Link>
+  );
 }

--- a/app/src/components/action_object_search/VideoGrid.tsx
+++ b/app/src/components/action_object_search/VideoGrid.tsx
@@ -1,4 +1,4 @@
-import { Grid, GridItem, Link } from '@chakra-ui/react';
+import { Grid, GridItem } from '@chakra-ui/react';
 import {
   type VideoSegmentQueryType,
   type VideoQueryType,

--- a/app/src/components/action_object_search/VideoGrid.tsx
+++ b/app/src/components/action_object_search/VideoGrid.tsx
@@ -4,12 +4,7 @@ import {
   type VideoQueryType,
 } from 'utils/action_object_search/sparql';
 import React from 'react';
-import { Link as ReactRouterLink } from 'react-router-dom';
-import {
-  IRI_KEY,
-  MAIN_OBJECT_KEY,
-  TARGET_OBJECT_KEY,
-} from 'constants/action_object_search/constants';
+import { ImagePageLink } from './ImagePageLink';
 
 function getVideoDurationAsMediaFragment(video: VideoSegmentQueryType) {
   const frameRate = Number(video.frameRate.value);
@@ -48,20 +43,18 @@ export function VideoGrid({
               width="100%"
               height="auto"
             />
-            <Link
-              as={ReactRouterLink}
-              to={`/action-object-search/2d-bbox-image?${new URLSearchParams({
-                [MAIN_OBJECT_KEY]: mainObject,
-                [TARGET_OBJECT_KEY]: targetObject,
-                [IRI_KEY]: hasVideoSegment
-                  ? video.videoSegment.value
-                  : video.camera.value,
-              }).toString()}`}
-            >
-              {hasVideoSegment
-                ? video.videoSegment.value.split('/').pop()
-                : video.camera.value.split('/').pop()}
-            </Link>
+            <ImagePageLink
+              linkText={
+                hasVideoSegment
+                  ? video.videoSegment.value.split('/').pop() || ''
+                  : video.camera.value.split('/').pop() || ''
+              }
+              mainObject={mainObject}
+              targetObject={targetObject}
+              iri={
+                hasVideoSegment ? video.videoSegment.value : video.camera.value
+              }
+            ></ImagePageLink>
           </GridItem>
         );
       })}

--- a/app/src/constants/action_object_search/constants.ts
+++ b/app/src/constants/action_object_search/constants.ts
@@ -21,3 +21,5 @@ export const SCENE_KEY: SearchParamKey = 'scene';
 export const CAMERA_KEY: SearchParamKey = 'camera';
 export const IRI_KEY: SearchParamKey = 'iri';
 export const IMAGE_VIEWER_PAGE_KEY: SearchParamKey = 'imageViewerPage';
+
+export const VIDEO_SEARCH_SESSION_STORAGE_KEY = 'videoSearchParams';

--- a/app/src/constants/action_object_search/constants.ts
+++ b/app/src/constants/action_object_search/constants.ts
@@ -21,5 +21,3 @@ export const SCENE_KEY: SearchParamKey = 'scene';
 export const CAMERA_KEY: SearchParamKey = 'camera';
 export const IRI_KEY: SearchParamKey = 'iri';
 export const IMAGE_VIEWER_PAGE_KEY: SearchParamKey = 'imageViewerPage';
-
-export const VIDEO_SEARCH_SESSION_STORAGE_KEY = 'videoSearchParams';

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Center, ChakraProvider } from '@chakra-ui/react';
-import { ReturnVideoSearchButton } from 'components/action_object_search/2d-bbox-image/ReturnVideoSearchButton';
+import { BackToVideoSearchButton } from 'components/action_object_search/2d-bbox-image/BackToVideoSearchButton';
 import { Pagination } from 'components/action_object_search/Pagination';
 import {
   IMAGE_VIEWER_PAGE_KEY,
@@ -116,7 +116,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
             totalElements={frameCount}
             displayedElementsPerPage={TOTAL_IMAGES_PER_PAGE}
           />
-          <ReturnVideoSearchButton />
+          <BackToVideoSearchButton />
         </Box>
       </Center>
     </ChakraProvider>

--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Center, ChakraProvider } from '@chakra-ui/react';
+import { ReturnVideoSearchButton } from 'components/action_object_search/2d-bbox-image/ReturnVideoSearchButton';
 import { Pagination } from 'components/action_object_search/Pagination';
 import {
   IMAGE_VIEWER_PAGE_KEY,
@@ -115,6 +116,7 @@ function BoundingBoxImageViewer(): React.ReactElement {
             totalElements={frameCount}
             displayedElementsPerPage={TOTAL_IMAGES_PER_PAGE}
           />
+          <ReturnVideoSearchButton />
         </Box>
       </Center>
     </ChakraProvider>

--- a/app/src/pages/action_object_search/index.tsx
+++ b/app/src/pages/action_object_search/index.tsx
@@ -24,6 +24,7 @@ import {
   TOTAL_VIDEOS_PER_PAGE,
   SCENE_KEY,
   CAMERA_KEY,
+  VIDEO_SEARCH_SESSION_STORAGE_KEY,
 } from 'constants/action_object_search/constants';
 import {
   type ActionQueryType,
@@ -201,6 +202,12 @@ function ActionObjectSearch(): React.ReactElement {
     }
     setSearchResultPage(1);
     handleSearchParamsChange(SEARCH_RESULT_PAGE_KEY, '1');
+
+    sessionStorage.removeItem(VIDEO_SEARCH_SESSION_STORAGE_KEY);
+    sessionStorage.setItem(
+      VIDEO_SEARCH_SESSION_STORAGE_KEY,
+      searchParams.toString()
+    );
   }, [
     selectedAction,
     mainObject,


### PR DESCRIPTION
## 変更の概要
- 画像表示ページから動画検索ページへ戻るボタンを追加しました
## なぜこの変更をするのか
- それぞれのページ間での移動が行いやすくなるためです
## やったこと
- `app/src/components/action_object_search/2d-bbox-image/ReturnVideoSearchButton.tsx`にボタン要素の作成
- `app/src/components/action_object_search/ImagePageLink.tsx`に画像表示ページへのリンク要素を作成
- sessionStorageを上記の要素で使用し、動画に対する検索内容を保存するようにしました

## やらないこと
- 動画検索ページにて`Pagination`要素のページを指定してもそのページへ遷移せず、1ページ目を表示するバグの修正
今回のPRとは別の箇所で発生している問題のため、別PRを作成して修正を行います。
BoundingBoxの表示を行った後に修正を行いたいと考えております。

## できるようになること
- 画像表示ページ→動画検索ページへの遷移がボタンのクリックで行うことができるようになります
## できなくなること
## 動作確認方法
## その他
添付のスクリーンショットと録画を併せてご確認ください。
<img width="1840" alt="Screenshot 2024-11-26 at 14 55 00" src="https://github.com/user-attachments/assets/860df1a3-25da-42e0-834e-40e9483bdbde">


https://github.com/user-attachments/assets/fadb6822-caaf-466d-b009-a826ba5f3dba

