### PR TITLE
Bounding Boxの描画機能を作成

### DIFF
--- a/app/src/components/action_object_search/VideoGrid.tsx
+++ b/app/src/components/action_object_search/VideoGrid.tsx
@@ -4,7 +4,7 @@ import {
   type VideoQueryType,
 } from 'utils/action_object_search/sparql';
 import React from 'react';
-import { ImagePageLink } from './ImagePageLink';
+import { ImagePageLink } from 'components/action_object_search/ImagePageLink';
 
 function getVideoDurationAsMediaFragment(video: VideoSegmentQueryType) {
   const frameRate = Number(video.frameRate.value);


### PR DESCRIPTION
## 変更の概要
- 画像表示ページに、Bounding Boxの描画機能を追加しました
## なぜこの変更をするのか
- 検索条件で指定したObjectのBoundingBoxを確認できるようにするためです
## やったこと
- `app/src/utils/action_object_search/2d-bbox-image/sparql.ts`にBounding Box情報を取得する関数を追加しました
- `app/src/pages/action_object_search/2d-bbox-image/index.tsx`にBounding Boxを描画する処理を追加しました
## やらないこと
- 
## できるようになること
- Bounding Boxが表示できるようになります
## できなくなること
- 
## 動作確認方法
- 
## その他
- 1点相対パスインポートを行なっている箇所があったため、そちらの修正も行なっております。
- 添付のスクリーンショットと録画を併せてご確認ください

<img width="1840" alt="Screenshot 2024-11-28 at 14 08 58" src="https://github.com/user-attachments/assets/5697f93e-878d-4060-9878-1f772e8381f6">

https://github.com/user-attachments/assets/bda2a73f-8bab-40e8-ae08-2b8bbb619390
