### PR TITLE
Paginationに1ページ目以外を指定していても1ページ目が表示される不具合の修正

### DIFF
--- a/app/src/pages/action_object_search/index.tsx
+++ b/app/src/pages/action_object_search/index.tsx
@@ -39,7 +39,7 @@ import {
   type VideoSegmentQueryType,
 } from 'utils/action_object_search/sparql';
 import FloatingNavigationLink from 'components/common/FloatingNavigationLink';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { SelectScene } from 'components/action_object_search/SelectScene';
 import { SelectCamera } from 'components/action_object_search/SelectCamera';
@@ -80,17 +80,25 @@ function ActionObjectSearch(): React.ReactElement {
     searchParams.get(CAMERA_KEY) || ''
   );
 
-  const isFirstRender = useRef(true);
-
   const isAnyRequiredParamsEmpty = selectedAction === '' || mainObject === '';
 
   const handleSearchParamsChange = useCallback(
     (key: SearchParamKey, value: string) => {
       const newSearchParams = new URLSearchParams(searchParams);
       newSearchParams.set(key, value);
+      if (key !== SEARCH_RESULT_PAGE_KEY) {
+        setSearchResultPage(1);
+        newSearchParams.set(SEARCH_RESULT_PAGE_KEY, '1');
+      }
       setSearchParams(newSearchParams);
+
+      sessionStorage.removeItem(VIDEO_SEARCH_SESSION_STORAGE_KEY);
+      sessionStorage.setItem(
+        VIDEO_SEARCH_SESSION_STORAGE_KEY,
+        newSearchParams.toString()
+      );
     },
-    [searchParams, setSearchParams]
+    [searchParams, setSearchParams, setSearchResultPage]
   );
 
   useEffect(() => {
@@ -195,19 +203,6 @@ function ActionObjectSearch(): React.ReactElement {
         )
       );
     })();
-
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-    setSearchResultPage(1);
-    handleSearchParamsChange(SEARCH_RESULT_PAGE_KEY, '1');
-
-    sessionStorage.removeItem(VIDEO_SEARCH_SESSION_STORAGE_KEY);
-    sessionStorage.setItem(
-      VIDEO_SEARCH_SESSION_STORAGE_KEY,
-      searchParams.toString()
-    );
   }, [
     selectedAction,
     mainObject,


### PR DESCRIPTION
## 変更の概要
- Paginationに1ページ目以外を指定していても1ページ目が表示される不具合を修正しました
## なぜこの変更をするのか
- クエリパラメータにページが指定されている場合に、途中からページを表示できるようにするためです
## やったこと
`app/src/pages/action_object_search/index.tsx`を変更しました
- `handleSearchParamsChange()`にて、ページ以外が変更された場合にページを1に戻す処理を追加しました
- `handleSearchParamsChange()`内部に、sessionStorageを更新する処理を移動しました
- `useEffect()`内部に存在した上記のと同様の処理を削除しました
## やらないこと
- 
## できるようになること
- クエリパラメータにページが指定されている場合に、途中からページを表示できるようになります
## できなくなること
- 
## 動作確認方法
- 
## その他
- お手数ですが、併せて録画をご確認ください。


https://github.com/user-attachments/assets/2caa4fc3-e1f4-48b2-8576-5f7a4ccf5867

