### PR TITLE
nginxコンテナの設定ファイルをコンテナ作成時に読み込むように変更

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   app:
@@ -10,24 +10,25 @@ services:
       - 5050:80
     volumes:
       - ./app/build:/usr/share/nginx/html
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
 
   react:
     image: node:20
     volumes:
       - ./app:/app
     command: sh -c "chmod +x /app/entrypoint.sh && /app/entrypoint.sh"
-  
+
   graphdb:
     image: ontotext/graphdb:10.4.4-arm64
     ports:
       - 7200:7200
-    entrypoint: [ "/opt/graphdb/entrypoint.sh" ]
+    entrypoint: ["/opt/graphdb/entrypoint.sh"]
     volumes:
       - ./.graphdb-data:/opt/graphdb/home
       - ./RDF:/opt/graphdb/home/graphdb-import
       - ./graphdb-repo-config.ttl:/opt/graphdb/graphdb-repo-config.ttl
       - ./entrypoint.sh:/opt/graphdb/entrypoint.sh
-    environment:  
+    environment:
       GDB_JAVA_OPTS: >-
         -Xmx2g -Xms2g
         -Dgraphdb.home=/opt/graphdb/home

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,44 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
## 変更の概要
- nginxコンテナの設定ファイルを作成し、コンテナ作成時にそれをマウントするように変更しました
## なぜこの変更をするのか
- build後にnginx上で新規検索ツールを実行した際に、再読み込みを行うとnginxで404エラーが発生する問題を解決するためです
## やったこと
- 設定ファイルを作成しました（`nginx/default.conf`）
- 上記ファイルをマウントするように`compose.yaml`を編集しました
## やらないこと
## できるようになること
## できなくなること
## 動作確認方法
お手数ですが添付の録画ファイルをご確認ください。
## その他

https://github.com/user-attachments/assets/5a90d7ea-deb4-455b-8ee0-71b5289fc750

