### PR TITLE
CLI: 動画セグメントの出力機能を追加

### DIFF
--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 import importlib
 
-from sparql import get_frames_for_video_segment
+from sparql import get_frames_of_video_segment
 
 
 def main():
@@ -41,13 +41,13 @@ def get_args():
 
 def output_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None, absolute_output_path: str):
     output_video = importlib.import_module('mmkg-search').output_video
-    frames = get_frames_for_video_segment(action, main_object, target_object, camera)
-    for segment_name in frames.keys():
-        split_segment_name = segment_name.split('_') # ['clean', 'sink3', '1', 'scene7', 'video', 'segment10']
-        (*activity_name_word_list, camera_number, scene, _, _) = split_segment_name
+    frames = get_frames_of_video_segment(action, main_object, target_object, camera)
+    for video_segment_name in frames.keys():
+        split_video_segment_name = video_segment_name.split('_') # ['clean', 'sink3', '1', 'scene7', 'video', 'segment10']
+        (*activity_name_word_list, camera_number, scene, _, _) = split_video_segment_name
         activity = '_'.join(activity_name_word_list)
 
-        output_video(activity, scene, "camera" + camera_number, {segment_name: frames[segment_name]}, absolute_output_path)
+        output_video(activity, scene, "camera" + camera_number, {video_segment_name: frames[video_segment_name]}, absolute_output_path)
 
 
 if __name__ == '__main__':

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -41,10 +41,10 @@ def output_video_segment(action: str, main_object: str, target_object: str | Non
     frames = get_frames_for_video_segment(action, main_object, target_object, camera)
     for segment_name in frames.keys():
         split_segment_name = segment_name.split('_') # ['clean', 'sink3', '1', 'scene7', 'video', 'segment10']
-        (*activity_name_word_list, camera, scene, _, _) = split_segment_name
+        (*activity_name_word_list, camera_number, scene, _, _) = split_segment_name
         activity = '_'.join(activity_name_word_list)
 
-        output_video(activity, scene, "camera" + camera, {segment_name: frames[segment_name]}, absolute_output_path)
+        output_video(activity, scene, "camera" + camera_number, {segment_name: frames[segment_name]}, absolute_output_path)
 
 
 if __name__ == '__main__':

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -10,13 +10,16 @@ def main():
 
     action: str = args.action
     main_object: str = args.__getattribute__('main-object')
-    target_object: str = args.target_object
-    camera: str = args.camera
+    target_object: str | None = args.target_object
+    camera: str | None = args.camera
     is_full: bool = args.full
     is_segment: bool = args.segment
     output_path: str = args.__getattribute__('output-path')
 
-    absolute_output_path = Path(output_path).resolve()
+    absolute_output_path = str(Path(output_path).resolve())
+
+    if is_segment:
+        output_video_segment(action, main_object, target_object, camera, absolute_output_path)
 
 
 def get_args():

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -1,5 +1,8 @@
 import argparse
 from pathlib import Path
+import importlib
+
+from sparql import get_frames_for_video_segment
 
 
 def main():
@@ -31,6 +34,18 @@ def get_args():
     parser.add_argument("output-path", type=str, help="The directory to save the search results (can be relative or absolute)")
 
     return parser.parse_args()
+
+
+def output_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None, absolute_output_path: str):
+    output_video = importlib.import_module('mmkg-search').output_video
+    frames = get_frames_for_video_segment(action, main_object, target_object, camera)
+    for segment_name in frames.keys():
+        split_segment_name = segment_name.split('_') # ['clean', 'sink3', '1', 'scene7', 'video', 'segment10']
+        (*activity_name_word_list, camera, scene, _, _) = split_segment_name
+        activity = '_'.join(activity_name_word_list)
+
+        output_video(activity, scene, "camera" + camera, {segment_name: frames[segment_name]}, absolute_output_path)
+
 
 if __name__ == '__main__':
     main()

--- a/cli/sparql.py
+++ b/cli/sparql.py
@@ -263,7 +263,7 @@ select DISTINCT ?action ?main_object ?target_object  where {
 
     return annotation_list
 
-def get_frames_for_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None):
+def get_frames_of_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None):
     from SPARQLWrapper import SPARQLWrapper, JSON
 
     query = f"""


### PR DESCRIPTION
## 変更の概要
- 新規検索ツールのCLI版で動画セグメントを出力する機能を追加しました
## なぜこの変更をするのか
- 新規検索ツールの動画セグメントフラグが指定された場合に、動画セグメントを検索結果として出力する必要があるためです
## やったこと
- `cli/sparql.py`に動画セグメントのIRI、開始フレーム、終了フレームを取得するクエリを作成しました
- `cli/action_object_search.py`に既存の検索ツールの`output_video()`を用いて動画セグメントを出力する機能を作成しました。
## やらないこと
- 
## できるようになること
- 実行時に`-s`が指定されると、検索結果が存在する場合に動画セグメントが出力されるようになります
## できなくなること
- 
## 動作確認方法
- 
## その他