### PR TITLE
Get videos

### DIFF
--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 import importlib
 
-from sparql import get_frames_for_video_segment, get_cameras
+from sparql import get_frames_of_video_segment, get_cameras
 
 
 def main():
@@ -20,7 +20,7 @@ def main():
 
     if is_segment:
         output_video_segment(action, main_object, target_object, camera, absolute_output_path)
-    else:
+    if is_full:
         output_full_video(action, main_object, target_object, camera, absolute_output_path)
 
 

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 import importlib
 
-from sparql import get_frames_of_video_segment
+from sparql import get_frames_for_video_segment, get_cameras
 
 
 def main():
@@ -20,6 +20,8 @@ def main():
 
     if is_segment:
         output_video_segment(action, main_object, target_object, camera, absolute_output_path)
+    else:
+        output_full_video(action, main_object, target_object, camera, absolute_output_path)
 
 
 def get_args():
@@ -37,6 +39,16 @@ def get_args():
     parser.add_argument("output-path", type=str, help="The directory to save the search results (can be relative or absolute)")
 
     return parser.parse_args()
+
+
+def output_full_video(action: str, main_object: str, target_object: str | None, camera: str | None, absolute_output_path: str):
+    output_video = importlib.import_module('mmkg-search').output_video
+    camera_list = get_cameras(action, main_object, target_object, camera)
+    frame_list = {'all': {'start_frame': None, 'end_frame': None}}
+    for camera in camera_list:
+        [*activity_name_word_list, scene, camera] = camera.split('_')
+        activity = '_'.join(activity_name_word_list)
+        output_video(activity, scene, camera, frame_list,absolute_output_path)
 
 
 def output_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None, absolute_output_path: str):

--- a/cli/sparql.py
+++ b/cli/sparql.py
@@ -274,7 +274,7 @@ def get_cameras(action: str, main_object: str, target_object: str | None, camera
         SELECT DISTINCT ?camera WHERE {{
             ?main_object rdfs:label ?main_object_label FILTER regex(?main_object_label, "{main_object}", "i") .
             {
-                f'?target_object rdfs:label ?target_object_label FILTER regex(?target_object_label, "${target_object}", "i") .'
+                f'?target_object rdfs:label ?target_object_label FILTER regex(?target_object_label, "{target_object}", "i") .'
 
                 if target_object is not None else ''
             }

--- a/cli/sparql.py
+++ b/cli/sparql.py
@@ -263,7 +263,47 @@ select DISTINCT ?action ?main_object ?target_object  where {
 
     return annotation_list
 
-def get_frames_of_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None):
+
+def get_cameras(action: str, main_object: str, target_object: str | None, camera: str | None):
+    from SPARQLWrapper import SPARQLWrapper, JSON
+
+    query = f"""
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+
+        SELECT DISTINCT ?camera WHERE {{
+            ?main_object rdfs:label ?main_object_label FILTER regex(?main_object_label, "{main_object}", "i") .
+            {
+                f'?target_object rdfs:label ?target_object_label FILTER regex(?target_object_label, "${target_object}", "i") .'
+
+                if target_object is not None else ''
+            }
+            ?event vh2kg:mainObject ?main_object ;
+                 {'vh2kg:targetObject ?target_object ;' if target_object is not None else ''}
+                   vh2kg:action ?action .
+            ?scene vh2kg:hasEvent ?event ;
+                   vh2kg:hasVideo ?camera .
+            FILTER regex(STR(?action), "{action}", "i") .
+            {f'FILTER regex(STR(?camera), "camera{camera}", "i") .' if camera is not None else ''}
+        }}
+    """
+
+    sparql = SPARQLWrapper(ENDPOINT)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+
+    bindings = results["results"]["bindings"]
+
+    camera_list = []
+    for binding in bindings:
+        camera = binding["camera"]["value"].replace(PREFIX_EX, "")
+        camera_list.append(camera)
+    
+    return camera_list
+
+
+def get_frames_for_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None):
     from SPARQLWrapper import SPARQLWrapper, JSON
 
     query = f"""

--- a/cli/sparql.py
+++ b/cli/sparql.py
@@ -303,7 +303,7 @@ def get_cameras(action: str, main_object: str, target_object: str | None, camera
     return camera_list
 
 
-def get_frames_for_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None):
+def get_frames_of_video_segment(action: str, main_object: str, target_object: str | None, camera: str | None):
     from SPARQLWrapper import SPARQLWrapper, JSON
 
     query = f"""


### PR DESCRIPTION
## 変更の概要

- CLI版の検索ツールに動画の出力機能を追加しました。

## なぜこの変更をするのか

- `--full`のフラグが指定された場合に、指定されたObjectとActionを含む動画を出力する機能が必要なためです。

## やったこと

- `cli/sparql.py`に、指定された`action`, `main_object`, `target_object`を含む`camera`(activity, scene, cameraを含むIRIの部分)を取得するクエリを追加しました
- 上記のクエリの結果を用いて、既存の`output_video()`関数を用いて動画を出力する機能を作成しました。

## やらないこと

## できるようになること
- `--full`フラグが指定された場合は、検索結果として動画全体を出力できるようになります
## できなくなること

## 動作確認方法

## その他
