### PR TITLE
画像を出力する機能の作成

### DIFF
--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -23,6 +23,8 @@ def main():
     if is_full:
         output_full_video(action, main_object, target_object, camera, absolute_output_path)
 
+    output_image_by_action_and_object(action, main_object, target_object, camera, absolute_output_path)
+
 
 def get_args():
     parser = argparse.ArgumentParser(

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 import importlib
 
-from sparql import get_frames_of_video_segment, get_cameras
+from sparql import get_frames_of_video_segment, get_cameras, get_object_containing_frames
 
 
 def main():
@@ -23,7 +23,7 @@ def main():
     if is_full:
         output_full_video(action, main_object, target_object, camera, absolute_output_path)
 
-    output_image_by_action_and_object(action, main_object, target_object, camera, absolute_output_path)
+    output_object_containing_image(action, main_object, target_object, camera, absolute_output_path)
 
 
 def get_args():
@@ -62,6 +62,15 @@ def output_video_segment(action: str, main_object: str, target_object: str | Non
         activity = '_'.join(activity_name_word_list)
 
         output_video(activity, scene, "camera" + camera_number, {video_segment_name: frames[video_segment_name]}, absolute_output_path)
+
+
+def output_object_containing_image(action: str, main_object: str, target_object: str | None, camera: str | None, absolute_output_path: str):
+    output_image = importlib.import_module('mmkg-search').output_image
+    video_segment_names = get_frames_of_video_segment(action, main_object, target_object, camera).keys()
+    for video_segment_name in video_segment_names:
+        frame_lists = get_object_containing_frames(video_segment_name, main_object, target_object)
+        for frame_list in frame_lists:
+            output_image(frame_list, absolute_output_path)
 
 
 if __name__ == '__main__':

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -1,8 +1,12 @@
 import argparse
 from pathlib import Path
 import importlib
+import base64
+import tempfile
+import os
 
-from sparql import get_frames_of_video_segment, get_cameras, get_object_containing_frames
+from sparql import get_frames_of_video_segment, get_cameras, get_object_containing_frames, get_video
+import cv2
 
 
 def main():
@@ -65,12 +69,77 @@ def output_video_segment(action: str, main_object: str, target_object: str | Non
 
 
 def output_object_containing_image(action: str, main_object: str, target_object: str | None, camera: str | None, absolute_output_path: str):
-    output_image = importlib.import_module('mmkg-search').output_image
     video_segment_names = get_frames_of_video_segment(action, main_object, target_object, camera).keys()
     for video_segment_name in video_segment_names:
-        frame_lists = get_object_containing_frames(video_segment_name, main_object, target_object)
-        for frame_list in frame_lists:
-            output_image(frame_list, absolute_output_path)
+        with TemporaryVideoFile(video_segment_name) as tmp_video:
+            if tmp_video is None:
+                continue
+            frame_lists = get_object_containing_frames(video_segment_name, main_object, target_object)
+            for frame_list in frame_lists:
+                output_image_from_video(tmp_video.name, frame_list, absolute_output_path)
+
+
+def output_image_from_video(video_path, frame_list, absolute_output_path):
+    image_directory_path = absolute_output_path + "/images"
+    if not os.path.exists(image_directory_path):
+        os.makedirs(image_directory_path)
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        print("Cannot open video")
+        return
+
+    for video_segment_name in frame_list:
+        if video_segment_name == 'all':
+            continue
+
+        frame_count = 0
+        success = True
+        
+        while success:
+            success, image = cap.read()
+
+            if frame_count % 5 != 0:
+                frame_count += 1
+                continue
+            if frame_count < frame_list[video_segment_name]['start_frame']:
+                frame_count += 1
+                continue
+            if frame_count > frame_list[video_segment_name]['end_frame']:
+                break
+
+            frame_path = image_directory_path + "/" + video_segment_name + "_frame" + str(frame_count).zfill(4) + ".jpg"
+            cv2.imwrite(frame_path, image)
+            print("Image saved to " + frame_path)
+            frame_count += 1
+
+    cap.release()
+
+
+class TemporaryVideoFile:
+    def __init__(self, video_segment_name: str):
+        (*activity_name_word_list, camera_number, scene, _, _) = video_segment_name.split('_')
+        activity = '_'.join(activity_name_word_list)
+
+        results = get_video(activity, scene, "camera" + camera_number)
+
+        bindings = results["results"]["bindings"]
+        if len(bindings) == 0:
+            print("No video found")
+            self.tmp_file = None
+
+        result = bindings[0]
+        video_base64 = result["video"]["value"]
+        video_binary = base64.b64decode(video_base64)
+
+        self.tmp_file = tempfile.NamedTemporaryFile(suffix=".mp4")
+        self.tmp_file.write(video_binary)
+
+    def __enter__(self):
+        return self.tmp_file
+
+    def __exit__(self, *args):
+        self.tmp_file.close()
 
 
 if __name__ == '__main__':

--- a/cli/sparql.py
+++ b/cli/sparql.py
@@ -348,3 +348,56 @@ def get_frames_of_video_segment(action: str, main_object: str, target_object: st
         frame_list[video_segment] = {'start_frame': start_frame, 'end_frame': end_frame}
 
     return frame_list
+
+
+def get_frames_by_object(video_segment_name: str, main_object: str, target_object:str | None):
+    from SPARQLWrapper import SPARQLWrapper, JSON
+
+    is_target_object_specified = target_object is not None
+    
+    query = f"""
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
+        PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        SELECT DISTINCT ?frame_number WHERE {{ 
+            BIND (<{PREFIX_EX + video_segment_name}> AS ?video_segment) .
+            BIND ("{main_object}" AS ?main_object_name) .
+            {f'BIND ("{target_object}" AS ?target_object_name) .' if is_target_object_specified else ''}
+            
+            ?scene vh2kg:hasVideo ?camera .
+            ?scene vh2kg:hasEvent ?event .
+            ?event vh2kg:mainObject ?main_object .
+            {'?event vh2kg:targetObject ?targetObject .' if is_target_object_specified else ''}
+            
+            ?camera mssn:hasMediaSegment ?video_segment .
+            ?video_segment mssn:hasMediaDescriptor ?frame .
+            ?frame mssn:hasMediaDescriptor ?object .
+            {
+                r'{{?object vh2kg:is2DbboxOf ?main_object} UNION {?object vh2kg:is2DbboxOf ?targetObject}} .'
+                if is_target_object_specified else
+                '?object vh2kg:is2DbboxOf ?main_object .'
+            }
+            ?frame vh2kg:frameNumber ?frame_number .
+            
+            ?main_object rdfs:label ?main_object_label .
+            {'?targetObject rdfs:label ?target_object_label .' if is_target_object_specified else ''}
+            FILTER regex(?main_object_label, ?main_object_name, "i") .
+            {'FILTER regex(?target_object_label, ?target_object_name, "i") .' if is_target_object_specified else ''}
+        }}
+    """
+
+    sparql = SPARQLWrapper(ENDPOINT)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+
+    bindings = results["results"]["bindings"]
+
+    frame_lists = []
+    for binding in bindings:
+        frame_number = int(binding["frame_number"]["value"])
+        frame_lists.append({video_segment_name: {'start_frame': frame_number, 'end_frame': frame_number}})
+
+    return frame_lists

--- a/cli/sparql.py
+++ b/cli/sparql.py
@@ -350,7 +350,7 @@ def get_frames_of_video_segment(action: str, main_object: str, target_object: st
     return frame_list
 
 
-def get_frames_by_object(video_segment_name: str, main_object: str, target_object:str | None):
+def get_object_containing_frames(video_segment_name: str, main_object: str, target_object:str | None):
     from SPARQLWrapper import SPARQLWrapper, JSON
 
     is_target_object_specified = target_object is not None


### PR DESCRIPTION
## 変更の概要
- CLI版新規検索ツールで、指定されたObjectを含む画像を出力する機能を作成しました
## なぜこの変更をするのか
- 新規検索ツールのCLI版の検索結果として、上記の条件の画像を出力する必要があるためです
## やったこと
- `cli/sparql.py`に指定されたObjectを含むフレームを取得する関数を作成しました
- 上記の関数で取得したフレーム情報をもとに、base64動画から画像を出力する関数`output_image_from_video()`を作成しました。
- 一時ファイルとして動画を保存するクラス`TemporaryVideoFile`を作成しました
## やらないこと
- 
## できるようになること
- 検索を行うと`main_object`あるいは`target_object`が映る画像が出力されるようになります
## できなくなること
- 
## 動作確認方法
- 
## その他
- 