### PR TITLE
想定していないフレームの画像が出力される不具合の修正

### DIFF
--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -93,27 +93,31 @@ def output_image_from_video(video_path, frame_list, absolute_output_path):
         if video_segment_name == 'all':
             continue
 
-        frame_count = 0
+        start_frame = frame_count = frame_list[video_segment_name]['start_frame']
+        end_frame = frame_list[video_segment_name]['end_frame']
+        frame_gap = 5
+
+        cap.set(cv2.CAP_PROP_POS_FRAMES, from_14_5_to_30_fps(start_frame))
         success = True
         
         while success:
-            success, image = cap.read()
-
-            if frame_count % 5 != 0:
-                frame_count += 1
-                continue
-            if frame_count < frame_list[video_segment_name]['start_frame']:
-                frame_count += 1
-                continue
-            if frame_count > frame_list[video_segment_name]['end_frame']:
+            if frame_count > end_frame:
                 break
+
+            success, image = cap.read()
 
             frame_path = image_directory_path + "/" + video_segment_name + "_frame" + str(frame_count).zfill(4) + ".jpg"
             cv2.imwrite(frame_path, image)
             print("Image saved to " + frame_path)
-            frame_count += 1
+            
+            frame_count += frame_gap
+            cap.set(cv2.CAP_PROP_POS_FRAMES, from_14_5_to_30_fps(frame_count))
 
     cap.release()
+
+
+def from_14_5_to_30_fps(frame_number):
+    return int(frame_number / 14.5 * 30)
 
 
 class TemporaryVideoFile:

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -98,13 +98,13 @@ def output_image_from_video(video_path, frame_list, absolute_output_path):
         frame_gap = 5
 
         cap.set(cv2.CAP_PROP_POS_FRAMES, from_14_5_to_30_fps(start_frame))
-        success = True
         
-        while success:
+        while True:
             if frame_count > end_frame:
                 break
-
             success, image = cap.read()
+            if not success:
+                break
 
             frame_path = image_directory_path + "/" + video_segment_name + "_frame" + str(frame_count).zfill(4) + ".jpg"
             cv2.imwrite(frame_path, image)


### PR DESCRIPTION
## 変更の概要
- 画像出力関数にて、意図したフレームが出力されない不具合を修正しました
## なぜこの変更をするのか
- 画像出力機能が実際に指定したactionとobjectを含む画像を出力できるようにするためです
## やったこと
- 14.5fpsのフレーム番号を30fpsのフレーム数へ変換する処理を追加
- `VideoCapture`の開始フレームを操作して目的のフレームを取得するように処理を変更
## やらないこと

## できるようになること
- 正確に`action`と`object`が含まれる画像を取得できるようになります。
## できなくなること

## 動作確認方法

## その他
