### PR TITLE
TSVの出力機能の追加

### DIFF
--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -149,6 +149,10 @@ class TemporaryVideoFile:
 
 
 def generate_tsv(action: str, main_object: str, target_object: str | None, camera: str | None, absolute_output_path: str):
+    annotation_directory = absolute_output_path + "/annotations"
+    if not os.path.exists(annotation_directory):
+        os.makedirs(annotation_directory)
+
     frames = get_frames_of_video_segment(action, main_object, target_object, camera)
     for video_segment_name in frames:
         scene = video_segment_name.split('_')[3]
@@ -160,7 +164,12 @@ def generate_tsv(action: str, main_object: str, target_object: str | None, camer
                 object_containing_bbox_annotations.append(bbox_annotation)
             if target_object is not None and target_object in bbox_annotation['object']:
                 object_containing_bbox_annotations.append(bbox_annotation)
-
+        
+        tsv_file_path = annotation_directory + "/" + video_segment_name + ".tsv"
+        with open(tsv_file_path, 'w') as tsv_file:
+            for annotation in object_containing_bbox_annotations:
+                tsv_file.write("\t".join([annotation['frame_number'], annotation['object'], annotation['2dbbox']]) + "\n")
+        print("2D Bounding Box Annotation saved to " + tsv_file_path)
 
 if __name__ == '__main__':
     main()

--- a/cli/action_object_search.py
+++ b/cli/action_object_search.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 from pathlib import Path
 import importlib
 import base64


### PR DESCRIPTION
## 変更の概要
- TSVファイルを出力する機能を追加しました
## なぜこの変更をするのか
- 新規検索ツールのCLI版の出力として、フレーム番号、オブジェクト、BBOX座標からなるTSVファイルが必要であるためです
## やったこと
- `cli/sparql.py`に`main_object`, `target_object`のbounding box情報を取得するクエリを作成しました
- 上記を使用して、`cli/action_object_search.py`にTSVファイルの出力機能を作成しました
## やらないこと
- 
## できるようになること
- 検索結果としてTSVファイルが出力されるようになります
## できなくなること
- 
## 動作確認方法
- 画像で出力しているフレーム番号と、出力されるBBOXのフレーム番号が一致していることを確認しました。
- `main_object`と`target_object`のみのTSV情報を出力していることを確認しました。
## その他
- 