### PR TITLE
GUI: base64動画から画像を切り抜くように変更

### DIFF
--- a/app/src/pages/action_object_search/2d-bbox-image/index.tsx
+++ b/app/src/pages/action_object_search/2d-bbox-image/index.tsx
@@ -9,14 +9,16 @@ import {
   TARGET_OBJECT_KEY,
   TOTAL_IMAGES_PER_PAGE,
 } from 'constants/action_object_search/constants';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, createRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   type FrameQueryType,
+  type VideoQueryType,
   fetchBoundingBox,
   fetchFrameByCamera,
   fetchFrameByVideoSegment,
-  fetchImage,
+  fetchVideoByCamera,
+  fetchVideoByVideoSegment,
 } from 'utils/action_object_search/2d-bbox-image/sparql';
 
 function BoundingBoxImageViewer(): React.ReactElement {
@@ -32,10 +34,13 @@ function BoundingBoxImageViewer(): React.ReactElement {
   );
   const [canvasContext, setCanvasContext] =
     useState<CanvasRenderingContext2D | null>(null);
+  const [video, setVideo] = useState<VideoQueryType | null>(null);
   const [resolution, setResolution] = useState<{
     width: number;
     height: number;
   }>({ width: 0, height: 0 });
+
+  const videoElementRef = createRef<HTMLVideoElement>();
 
   const isAnyRequiredParamEmpty = mainObject === '' || iri === '';
   const isVideoSegment = iri.includes('video_segment');
@@ -51,64 +56,43 @@ function BoundingBoxImageViewer(): React.ReactElement {
         return;
       }
 
+      let videoQueryResult;
       if (isVideoSegment) {
+        videoQueryResult = await fetchVideoByVideoSegment(iri);
         setFrames(
           await fetchFrameByVideoSegment(iri, mainObject, targetObject)
         );
       } else {
+        videoQueryResult = await fetchVideoByCamera(iri);
         setFrames(await fetchFrameByCamera(iri, mainObject, targetObject));
       }
+      setVideo(videoQueryResult);
+
+      if (videoQueryResult === null) {
+        return;
+      }
+
+      const [width, height] = videoQueryResult.resolution.value
+        .split('x')
+        .map((v) => Number(v)); // "1920x1080" -> [1920, 1080]
+      setResolution({ width, height });
     })();
   }, []);
 
   useEffect(() => {
-    (async () => {
+    (() => {
       if (frameCount === 0) {
         return;
       }
-      if (canvasContext === null) {
+      const frameIri = frames[imageViewerPage - 1].frame.value;
+      const frameNumber =
+        Number(frameIri.split('_').pop()?.replace('frame', '')) || 0;
+
+      if (videoElementRef.current === null) {
         return;
       }
-
-      const frameIri = frames[imageViewerPage - 1].frame.value;
-
-      const splitImages = await fetchImage(frameIri);
-
-      const [imageWidth, imageHeight] = splitImages[0].resolution.value
-        .split('x')
-        .map((v) => Number(v)); // "1920x1080" -> [1920, 1080]
-      setResolution({ width: imageWidth, height: imageHeight });
-
-      splitImages.forEach((image, index) => {
-        const img = new Image();
-        img.src = `data:image/jpeg;base64,${image.base64SplitImage.value}`;
-        img.onload = () => {
-          const x = (index % Number(image.splitWidth.value)) * img.width;
-          const y =
-            Math.floor(index / Number(image.splitHeight.value)) * img.height;
-          canvasContext.drawImage(img, x, y);
-        };
-      });
-
-      const boundingBoxes = await fetchBoundingBox(
-        frameIri,
-        mainObject,
-        targetObject
-      );
-
-      boundingBoxes.forEach((boundingBox) => {
-        const [leftX, topY, rightX, bottomY] =
-          boundingBox.boundingBoxValue.value.split(',').map((v) => Number(v));
-        boundingBox.label.value.includes(mainObject)
-          ? (canvasContext.strokeStyle = 'red')
-          : (canvasContext.strokeStyle = 'blue');
-        canvasContext?.strokeRect(
-          leftX,
-          imageHeight - topY, // Y軸はRDFとcanvasで上下が逆
-          rightX - leftX,
-          topY - bottomY
-        );
-      });
+      videoElementRef.current.currentTime =
+        frameNumber / Number(video?.frameRate.value);
     })();
   }, [frames, imageViewerPage]);
 
@@ -121,11 +105,62 @@ function BoundingBoxImageViewer(): React.ReactElement {
     [searchParams, setSearchParams]
   );
 
+  const handleTimeUpdate = useCallback(async () => {
+    if (frameCount === 0) {
+      return;
+    }
+    if (videoElementRef.current === null) {
+      return;
+    }
+    if (canvasContext === null) {
+      return;
+    }
+
+    const frameIri = frames[imageViewerPage - 1].frame.value;
+    canvasContext.clearRect(0, 0, resolution.width, resolution.height);
+    canvasContext.drawImage(
+      videoElementRef.current,
+      0,
+      0,
+      resolution.width,
+      resolution.height
+    );
+
+    const boundingBoxes = await fetchBoundingBox(
+      frameIri,
+      mainObject,
+      targetObject
+    );
+
+    boundingBoxes.forEach((boundingBox) => {
+      const [leftX, topY, rightX, bottomY] = boundingBox.boundingBoxValue.value
+        .split(',')
+        .map((v) => Number(v));
+      boundingBox.label.value.includes(mainObject)
+        ? (canvasContext.strokeStyle = 'red')
+        : (canvasContext.strokeStyle = 'blue');
+      canvasContext?.strokeRect(
+        leftX,
+        resolution.height - topY, // Y軸はRDFとcanvasで上下が逆
+        rightX - leftX,
+        topY - bottomY
+      );
+    });
+  }, [frames, imageViewerPage, resolution, mainObject, targetObject]);
+
   return (
     <ChakraProvider>
       <Center>
         <Box>
           <Center>
+            <video
+              style={{ display: 'none' }}
+              src={`data:video/mp4;base64,${video?.base64Video.value}`}
+              width="100%"
+              height="auto"
+              ref={videoElementRef}
+              onTimeUpdate={handleTimeUpdate}
+            />
             <canvas
               width={`${resolution.width}px`}
               height={`${resolution.height}px`}

--- a/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
+++ b/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
@@ -186,3 +186,31 @@ export const fetchBoundingBox: (
   )) as BoundingBoxQueryType[];
   return result;
 };
+
+export type VideoQueryType = {
+  base64Video: NamedNode;
+  resolution: NamedNode;
+  frameRate: NamedNode;
+  originalFrameRate: NamedNode;
+};
+export const fetchVideoByCamera: (
+  cameraIri: string
+) => Promise<VideoQueryType | null> = async (cameraIri) => {
+  const query = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT DISTINCT ?base64Video ?resolution ?frameRate ?originalFrameRate WHERE { 
+      BIND (<${cameraIri}> AS ?camera) .
+
+      ?camera vh2kg:video ?base64Video ;
+              vh2kg:hasResolution ?resolution ;
+              vh2kg:frameRate ?frameRate ;
+              vh2kg:originalFrameRate ?originalFrameRate .
+    }
+  `;
+  const result = (await makeClient().query.select(query)) as VideoQueryType[];
+  return result.pop() || null;
+};

--- a/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
+++ b/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
@@ -197,10 +197,7 @@ export const fetchVideoByCamera: (
   cameraIri: string
 ) => Promise<VideoQueryType | null> = async (cameraIri) => {
   const query = `
-    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
     PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
-    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
     SELECT DISTINCT ?base64Video ?resolution ?frameRate ?originalFrameRate WHERE { 
       BIND (<${cameraIri}> AS ?camera) .
@@ -219,10 +216,8 @@ export const fetchVideoByVideoSegment: (
   videoSegmentIri: string
 ) => Promise<VideoQueryType | null> = async (videoSegmentIri) => {
   const query = `
-    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
     PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
-    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
     SELECT DISTINCT ?base64Video ?resolution ?frameRate ?originalFrameRate WHERE { 
       BIND (<${videoSegmentIri}> AS ?videoSegment) .

--- a/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
+++ b/app/src/utils/action_object_search/2d-bbox-image/sparql.ts
@@ -214,3 +214,26 @@ export const fetchVideoByCamera: (
   const result = (await makeClient().query.select(query)) as VideoQueryType[];
   return result.pop() || null;
 };
+
+export const fetchVideoByVideoSegment: (
+  videoSegmentIri: string
+) => Promise<VideoQueryType | null> = async (videoSegmentIri) => {
+  const query = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX mssn: <http://mssn.sigappfr.org/mssn/>
+    PREFIX vh2kg: <http://kgrc4si.home.kg/virtualhome2kg/ontology/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT DISTINCT ?base64Video ?resolution ?frameRate ?originalFrameRate WHERE { 
+      BIND (<${videoSegmentIri}> AS ?videoSegment) .
+
+      ?camera mssn:hasMediaSegment ?videoSegment ;
+              vh2kg:video ?base64Video ;
+              vh2kg:hasResolution ?resolution ;
+              vh2kg:frameRate ?frameRate ;
+              vh2kg:originalFrameRate ?originalFrameRate .
+    }
+  `;
+  const result = (await makeClient().query.select(query)) as VideoQueryType[];
+  return result.pop() || null;
+};


### PR DESCRIPTION
## 変更の概要
- 2dbbox表示ページにて、base64動画から画像を切り抜くように変更しました
## なぜこの変更をするのか
- Graph DBに`splitImage`をImportせずに使用できるようにするためです
## やったこと
- `app/src/utils/action_object_search/2d-bbox-image/sparql.ts`に動画を取得するクエリを作成しました
- `app/src/pages/action_object_search/2d-bbox-image/index.tsx`を変更しました
  - `splitImage`を取得する処理を削除しました
  - 動画を取得する処理を追加しました
  - ページの変更に伴って、動画から切り抜いた画像とBounding Boxを描画するように変更しました
## やらないこと
- 
## できるようになること
- `splitImage`なしでBoundingBox表示ができるようになります
## できなくなること
- `splitImage`は表示できなくなります
## 動作確認方法
- 
## その他
- 添付の録画の確認もよろしくお願いいたします

https://github.com/user-attachments/assets/7a4deb46-90ca-4dad-b3ef-2ce75724910d



