### PR TITLE
BBOX情報が存在しない場合はTSVファイルを作成しないように修正

### DIFF
--- a/cli/action-object-search.py
+++ b/cli/action-object-search.py
@@ -155,6 +155,8 @@ def generate_tsv(action: str, main_object: str, target_object: str | None, camer
     video_segment_names = get_frames_of_video_segment(action, main_object, target_object, camera).keys()
     for video_segment_name in video_segment_names:
         bbox_annotations = get_annotation_2d_bbox_from_object(main_object, target_object, video_segment_name)
+        if len(bbox_annotations) == 0:
+            continue
 
         tsv_file_path = annotation_directory + "/" + video_segment_name + ".tsv"
         with open(tsv_file_path, 'w') as tsv_file:


### PR DESCRIPTION
## 変更の概要
- 検索ツールのCLI版にて、`videoSegment`に対応したBBOX情報が存在しない場合に空のTSVファイルを出力するバグを修正しました
## なぜこの変更をするのか
- バグ修正のためです
## やったこと
- BBOX情報が存在しない場合は、TSV出力をスキップするようにしました
## やらないこと
- 
## できるようになること
- 
## できなくなること
- 
## 動作確認方法
- `python action-object-search.py put bread -t fryingpan -f .`
このエラーが発生したコマンドで、空のTSVファイルが出力されないことを確認しました。

## その他
