### PR TITLE
CLI版検索ツールにLoadingの追加

### DIFF
--- a/cli/action-object-search.py
+++ b/cli/action-object-search.py
@@ -6,7 +6,7 @@ import tempfile
 import os
 import time
 import sys
-from urllib.error import URLError, HTTPError
+from urllib.error import URLError
 from sparql import check_database_connection, get_frames_of_video_segment, get_cameras, get_object_containing_frames, get_video, get_annotation_2d_bbox_from_object
 import cv2
 

--- a/cli/action-object-search.py
+++ b/cli/action-object-search.py
@@ -32,8 +32,7 @@ def main():
             check_database_connection()
             break
         except (ConnectionRefusedError, URLError):
-            print("Error: Cannot connect to the RDF database. Please check if the database container is running.")
-            sys.exit(1)
+            sys.exit("Error: Cannot connect to the RDF database. Please check if the database container is running.")
         except ConnectionResetError as e:
             if not has_printed_waiting_message:
                 print("The RDF database is loading the data. Please wait for a while...")

--- a/cli/sparql.py
+++ b/cli/sparql.py
@@ -3,6 +3,15 @@ PREFIX_VH2KG = "http://kgrc4si.home.kg/virtualhome2kg/ontology/"
 ENDPOINT = "http://localhost:7200/repositories/kgrc4si"
 
 
+def check_database_connection():
+    from SPARQLWrapper import SPARQLWrapper, JSON
+    sparql = SPARQLWrapper(ENDPOINT)
+    sparql.setQuery("ASK {}")
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+    return results["boolean"]
+
+
 def get_all_frames(activity, scene, camera):
     print("Searching for all frames...")
     from SPARQLWrapper import SPARQLWrapper, JSON


### PR DESCRIPTION
## 変更の概要
- CLI版の検索ツールにローディングの処理を追加しました
## なぜこの変更をするのか
- 追加仕様の対応のためです
## やったこと
- `cli/sparql.py`に接続を確認するためのクエリを追加しました
- 上記を用いて、発生するエラーに応じてLoading画面の表示を行うように変更しました
  - ConnectionRefusedError, URLエラーの場合は、データベースコンテナが起動していないというメッセージを表示してプログラムを終了するようにしました。
  - ConnectionResetErrorの場合は、データベースがデータを読み込んでいるため、待つ必要があるというメッセージを表示して、20秒おきに接続を確認し、データの読み込みが完了次第通常通り検索ツールを実行するようにしました

## やらないこと
- GUI版のローディング処理
別PRで作成します。
## できるようになること
- 
## できなくなること
- 
## 動作確認方法
- コンテナが起動していない場合（エラー表示でプログラム終了）
- コンテナが起動している場合
  - データベースを読み込んでいる場合（読み込み完了まで待機）
  - データベースの読み込みが完了している場合（検索ツールを実行）

で確認のうえ、期待した動作をしていました。
## その他
- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）