### PR TITLE
検索結果の動画名が長い場合に、折り返して表示するように変更

### DIFF
--- a/app/src/components/action_object_search/ImagePageLink.tsx
+++ b/app/src/components/action_object_search/ImagePageLink.tsx
@@ -7,6 +7,25 @@ import {
 } from 'constants/action_object_search/constants';
 import React from 'react';
 
+function splitVideoName(videoName: string) {
+  const pattern = /(.+)_(scene\d+)_(camera\d+)/;
+  const groups = pattern.exec(videoName)?.slice(1);
+  if (!groups) {
+    return videoName;
+  }
+  return groups.join(' ');
+}
+
+function splitVideoSegmentName(videoSegmentName: string) {
+  const pattern = /(.+)_(\d+)_(scene\d+)_(video_segment\d+)/;
+  const groups = pattern.exec(videoSegmentName)?.slice(1);
+  if (!groups) {
+    return videoSegmentName;
+  }
+  groups[1] = 'camera' + groups[1];
+  return groups.join(' ');
+}
+
 type ImagePageLinkProps = {
   linkText: string;
   mainObject: string;
@@ -27,8 +46,10 @@ export function ImagePageLink({
   const path =
     '/action-object-search/2d-bbox-image?' + imageSearchParams.toString();
   return (
-    <Link as={ReactRouterLink} to={path}>
-      {linkText}
+    <Link as={ReactRouterLink} to={path} overflowWrap={'break-word'}>
+      {linkText.includes('video_segment')
+        ? splitVideoSegmentName(linkText)
+        : splitVideoName(linkText)}
     </Link>
   );
 }


### PR DESCRIPTION
## 変更の概要
- 検索結果の動画名が長い場合に、折り返して表示するように変更しました
## なぜこの変更をするのか
- 追加修正の変更のためです
- 動画名が長い場合に、それに伴って検索結果の動画が大きく表示されてしまう問題を修正するためです
## やったこと
- `app/src/components/action_object_search/ImagePageLink.tsx`を修正しました
  - 動画・動画セグメント名のそれぞれに、要素の区切りにスペースを入れる処理を追加しました。（camera, scene, video_segment...など）
  - BBOX表示ページへのリンクテキストが長い場合はスペースで折り返すようにしました
## やらないこと
- 
## できるようになること
-
## できなくなること
- 
## 動作確認方法
- 
## その他
動画・動画セグメントの名前の表示のスクリーンショットを合わせてご確認ください

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/4b9dbd44-dcbd-46c7-a2d2-779a078d7899" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/8c1ffa58-0b4c-4fae-aec7-6519199a78ac" />
